### PR TITLE
Add a script to launch a webserver for fixtures easily

### DIFF
--- a/bin/mink-test-server
+++ b/bin/mink-test-server
@@ -5,7 +5,7 @@ set -o pipefail
 # fail harder
 set -eu
 
-base_dir=$(cd $(dirname $0); cd ..; pwd)
+base_dir=$(dirname "$(dirname "$(readlink -f "$0")")")
 host="localhost:8002"
 php_bin=${MINK_PHP_BIN-php}
 

--- a/bin/mink-test-server
+++ b/bin/mink-test-server
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# fail hard
+set -o pipefail
+# fail harder
+set -eu
+
+base_dir=$(cd $(dirname $0); cd ..; pwd)
+host="localhost:8002"
+php_bin=${MINK_PHP_BIN-php}
+
+# Use exec to make it easier to stop the process
+exec "$php_bin" -S "$host" -t "$base_dir/web-fixtures"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
 
+    "bin": [
+        "bin/mink-test-server"
+    ],
+
     "autoload": {
         "psr-4": {
             "Behat\\Mink\\Tests\\Driver\\": "tests/"

--- a/tests/AbstractConfig.php
+++ b/tests/AbstractConfig.php
@@ -39,6 +39,10 @@ abstract class AbstractConfig
      */
     public function getWebFixturesUrl()
     {
+        if (!isset($_SERVER['WEB_FIXTURES_HOST'])) {
+            return 'http://localhost:8002'; // Host used by default by mink-test-server
+        }
+
         return $_SERVER['WEB_FIXTURES_HOST'];
     }
 


### PR DESCRIPTION
I wrote it in bash for now, as it is very easy. It should work on windows when using Cygwin or GitBash (but I have not tried it yet).

I could have written it in PHP, but it would have been much more complex (launching a subprocess on PHP in a cross-platform way is not that simple, which is why Symfony has a component dedicated to that task)