### PR TITLE
Make the host configurable when running the server

### DIFF
--- a/bin/mink-test-server
+++ b/bin/mink-test-server
@@ -6,7 +6,7 @@ set -o pipefail
 set -eu
 
 base_dir=$(dirname "$(dirname "$(readlink -f "$0")")")
-host="localhost:8002"
+host=${MINK_HOST-localhost:8002}
 php_bin=${MINK_PHP_BIN-php}
 
 # Use exec to make it easier to stop the process


### PR DESCRIPTION
This is necessary to be able to use this script for the ZombieDriver testsuite on Travis. The goal is to force PHP to bin on IPv4, as zombie.js and PHP seem to have a different resolution for localhost on Travis (locally, I have no issue, as localhost resolves first to ipv4. But Travis resolves first to IPv6 except that Zombie.js will use IPv4)