### PR TITLE
Add an HttpKernel implementation exposing fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,17 @@
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
 
+    "require-dev": {
+        "symfony/http-kernel": "^2.3 || ^3.0"
+    },
+
     "bin": [
         "bin/mink-test-server"
     ],
 
     "autoload": {
         "psr-4": {
+            "Behat\\Mink\\Tests\\Driver\\Util\\": "src/",
             "Behat\\Mink\\Tests\\Driver\\": "tests/"
         }
     }

--- a/http-kernel-fixtures/404.php
+++ b/http-kernel-fixtures/404.php
@@ -1,0 +1,3 @@
+<?php
+
+$resp = new Symfony\Component\HttpFoundation\Response('Sorry, page not found', 404);

--- a/http-kernel-fixtures/500.php
+++ b/http-kernel-fixtures/500.php
@@ -1,0 +1,3 @@
+<?php
+
+$resp = new Symfony\Component\HttpFoundation\Response('Sorry, a server error happened', 500);

--- a/http-kernel-fixtures/advanced_form_post.php
+++ b/http-kernel-fixtures/advanced_form_post.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Advanced form save</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+</head>
+<body>
+<?php
+error_reporting(0);
+
+$POST = $request->request->all();
+$FILES = $request->files->all();
+
+if (isset($POST['select_multiple_numbers']) && false !== strpos($POST['select_multiple_numbers'][0], ',')) {
+    $POST['select_multiple_numbers'] = explode(',', $POST['select_multiple_numbers'][0]);
+}
+
+// checkbox can have any value and will be successful in case "on"
+// http://www.w3.org/TR/html401/interact/forms.html#checkbox
+$POST['agreement'] = isset($POST['agreement']) ? 'on' : 'off';
+ksort($POST);
+echo str_replace('>', '', var_export(html_escape_value($POST), true)) . "\n";
+if (isset($FILES['about']) && file_exists($FILES['about']->getPathname())) {
+    echo html_escape_value($FILES['about']->getClientOriginalName()) . "\n";
+    echo html_escape_value(file_get_contents($FILES['about']->getPathname()));
+} else {
+    echo "no file";
+}
+?>
+</body>
+</html>

--- a/http-kernel-fixtures/basic_auth.php
+++ b/http-kernel-fixtures/basic_auth.php
@@ -1,0 +1,15 @@
+<?php
+$SERVER = $request->server->all();
+
+$username = isset($SERVER['PHP_AUTH_USER']) ? $SERVER['PHP_AUTH_USER'] : false;
+$password = isset($SERVER['PHP_AUTH_PW']) ? $SERVER['PHP_AUTH_PW'] : false;
+
+if ($username == 'mink-user' && $password == 'mink-password') {
+    echo 'is authenticated';
+} else {
+    $resp = new \Symfony\Component\HttpFoundation\Response();
+    $resp->setStatusCode(401);
+    $resp->headers->set('WWW-Authenticate', 'Basic realm="Mink Testing Area"');
+
+    echo 'is not authenticated';
+}

--- a/http-kernel-fixtures/basic_form_post.php
+++ b/http-kernel-fixtures/basic_form_post.php
@@ -1,0 +1,14 @@
+<?php  ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Basic Form Saving</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+    <h1>Anket for <?php echo html_escape_value($request->request->get('first_name')) ?></h1>
+
+    <span id="first">Firstname: <?php echo html_escape_value($request->request->get('first_name')) ?></span>
+    <span id="last">Lastname: <?php echo html_escape_value($request->request->get('last_name')) ?></span>
+</body>
+</html>

--- a/http-kernel-fixtures/basic_get_form.php
+++ b/http-kernel-fixtures/basic_get_form.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Basic Get Form</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+    <h1>Basic Get Form Page</h1>
+
+    <div id="serach">
+        <?php
+        $GET = $request->query->all();
+        echo isset($GET['q']) && $GET['q'] ? html_escape_value($GET['q']) : 'No search query'
+        ?>
+    </div>
+
+    <form>
+        <input name="q" value="" type="text" />
+
+        <input type="submit" value="Find" />
+    </form>
+</body>
+</html>

--- a/http-kernel-fixtures/cookie_page1.php
+++ b/http-kernel-fixtures/cookie_page1.php
@@ -1,0 +1,17 @@
+<?php
+    $resp = new Symfony\Component\HttpFoundation\Response();
+    $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set', 0, '/');
+    $resp->headers->setCookie($cook);
+?>
+<!doctype html public "-//w3c//dtd xhtml 1.1//en" "http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>basic form</title>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8"/>
+    <script>
+    </script>
+</head>
+<body>
+    basic page with cookie set from server side
+</body>
+</html>

--- a/http-kernel-fixtures/cookie_page2.php
+++ b/http-kernel-fixtures/cookie_page2.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Basic Form</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <script>
+    </script>
+</head>
+<body>
+    Previous cookie: <?php
+        echo $request->cookies->has('srvr_cookie') ? html_escape_value($request->cookies->get('srvr_cookie')) : 'NO';
+    ?>
+</body>
+</html>

--- a/http-kernel-fixtures/cookie_page3.php
+++ b/http-kernel-fixtures/cookie_page3.php
@@ -1,0 +1,20 @@
+<?php
+
+$hasCookie = $request->cookies->has('foo');
+$resp = new Symfony\Component\HttpFoundation\Response();
+$cook = new Symfony\Component\HttpFoundation\Cookie('foo', 'bar');
+$resp->headers->setCookie($cook);
+
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>HttpOnly Cookie Test</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <script>
+    </script>
+</head>
+<body>
+    <div id="cookie-status">Has Cookie: <?php echo json_encode($hasCookie) ?></div>
+</body>
+</html>

--- a/http-kernel-fixtures/headers.php
+++ b/http-kernel-fixtures/headers.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Headers page</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+    <?php print_r($request->server->all()); ?>
+</body>
+</html>

--- a/http-kernel-fixtures/issue130.php
+++ b/http-kernel-fixtures/issue130.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<html>
+<body>
+    <?php
+    if ('1' === $request->query->get('p')) {
+        echo '<a href="/issue130.php?p=2">Go to 2</a>';
+    } else {
+        echo '<strong>'.html_escape_value($request->headers->get('referer')).'</strong>';
+    }
+    ?>
+</body>

--- a/http-kernel-fixtures/issue140.php
+++ b/http-kernel-fixtures/issue140.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<html>
+<body>
+<?php
+if ($request->isMethod('POST')) {
+    $resp = new Symfony\Component\HttpFoundation\Response();
+    $cook = new Symfony\Component\HttpFoundation\Cookie('tc', $request->request->get('cookie_value'));
+    $resp->headers->setCookie($cook);
+} elseif ($request->query->has('show_value')) {
+    echo html_escape_value($request->cookies->get('tc'));
+    return;
+}
+?>
+    <form method="post">
+        <input name="cookie_value">
+        <input type="submit" value="Set cookie">
+    </form>
+</body>

--- a/http-kernel-fixtures/print_cookies.php
+++ b/http-kernel-fixtures/print_cookies.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Cookies page</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+    <?php
+    $cookies = $request->cookies->all();
+    unset($cookies['MOCKSESSID']);
+
+    if (isset($cookies['srvr_cookie'])) {
+        $srvrCookie = $cookies['srvr_cookie'];
+        unset($cookies['srvr_cookie']);
+        $cookies['_SESS'] = '';
+        $cookies['srvr_cookie'] = $srvrCookie;
+    }
+
+    foreach ($cookies as $name => $val) {
+        $cookies[$name] = (string)$val;
+    }
+    echo str_replace(array('>'), '', var_export(html_escape_value($cookies), true));
+    ?>
+</body>
+</html>

--- a/http-kernel-fixtures/redirector.php
+++ b/http-kernel-fixtures/redirector.php
@@ -1,0 +1,3 @@
+<?php
+
+$resp = new Symfony\Component\HttpFoundation\RedirectResponse('/redirect_destination.html');

--- a/http-kernel-fixtures/response_headers.php
+++ b/http-kernel-fixtures/response_headers.php
@@ -1,0 +1,15 @@
+<?php
+    $resp = new Symfony\Component\HttpFoundation\Response();
+    $resp->headers->set('X-Mink-Test', 'response-headers');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Response headers</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+    <h1>Response headers</h1>
+</body>
+</html>
+

--- a/http-kernel-fixtures/session_test.php
+++ b/http-kernel-fixtures/session_test.php
@@ -1,0 +1,19 @@
+<?php
+$session = $request->getSession();
+
+if ($request->query->has('login')) {
+    $session->migrate();
+}
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Session Test</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <script>
+    </script>
+</head>
+<body>
+    <div id="session-id"><?php echo $session->getId() ?></div>
+</body>
+</html>

--- a/http-kernel-fixtures/sub-folder/cookie_page1.php
+++ b/http-kernel-fixtures/sub-folder/cookie_page1.php
@@ -1,0 +1,18 @@
+<?php
+    $requestUri = $request->server->get('REQUEST_URI');
+    $resp = new Symfony\Component\HttpFoundation\Response();
+    $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
+    $resp->headers->setCookie($cook);
+?>
+<!doctype html public "-//w3c//dtd xhtml 1.1//en" "http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>basic form</title>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8"/>
+    <script>
+    </script>
+</head>
+<body>
+    basic page with cookie set from server side
+</body>
+</html>

--- a/http-kernel-fixtures/sub-folder/cookie_page2.php
+++ b/http-kernel-fixtures/sub-folder/cookie_page2.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Basic Form</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <script>
+    </script>
+</head>
+<body>
+    Previous cookie: <?php
+    if ($request->cookies->has('srvr_cookie')) {
+        echo $request->cookies->get('srvr_cookie');
+    } else {
+        echo 'NO';
+    }
+    ?>
+</body>
+</html>

--- a/src/FixturesKernel.php
+++ b/src/FixturesKernel.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver\Util;
+
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class FixturesKernel implements HttpKernelInterface
+{
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    {
+        $this->prepareSession($request);
+
+        $response = $this->handleFixtureRequest($request);
+
+        $this->saveSession($request, $response);
+        $response->prepare($request);
+
+        return $response;
+    }
+
+    private function handleFixtureRequest(Request $request)
+    {
+        $fixturesDir = realpath(__DIR__.'/../web-fixtures');
+        $overwriteDir = realpath(__DIR__.'/../http-kernel-fixtures');
+
+        require_once $fixturesDir . '/utils.php';
+
+        $file = $request->getPathInfo();
+
+        $path = file_exists($overwriteDir.$file) ? $overwriteDir.$file : $fixturesDir.$file;
+
+        $resp = null;
+
+        ob_start();
+        require $path;
+        $content = ob_get_clean();
+
+        if ($resp instanceof Response) {
+            if ('' === $resp->getContent()) {
+                $resp->setContent($content);
+            }
+
+            return $resp;
+        }
+
+        return new Response($content);
+    }
+
+    private function prepareSession(Request $request)
+    {
+        $session = new Session(new MockFileSessionStorage());
+        $request->setSession($session);
+
+        $cookies = $request->cookies;
+
+        if ($cookies->has($session->getName())) {
+            $session->setId($cookies->get($session->getName()));
+        } else {
+            $session->migrate(false);
+        }
+    }
+
+    private function saveSession(Request $request, Response $response)
+    {
+        $session = $request->getSession();
+        if ($session && $session->isStarted()) {
+            $session->save();
+
+            $params = session_get_cookie_params();
+
+            $response->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
+        }
+    }
+}


### PR DESCRIPTION
This is meant to replace the Silex app used by BrowserKitDriver. This uses a minimalist implementation of the kernel, while still keeping support for sessions as our tests need it.
Fixtures files are copied from BrowserKitDriver, simply replacing the way to access the request.
Using HttpKernel directly rather than the full Silex allows to limit the needed dependencies (much easier to maintain, as they should stay optional dependencies as most drivers don't need it when running tests).