### PR TITLE
Add tests for handling of HTML5 formaction and formmethod

### DIFF
--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -125,4 +125,36 @@ OUT;
 
         $this->assertContains($out, $page->getContent());
     }
+
+    public function testHtml5FormAction()
+    {
+        $this->getSession()->visit($this->pathTo('html5_form.html'));
+        $page = $this->getSession()->getPage();
+
+        $page->fillField('first_name', 'Jimmy');
+        $page->pressButton('Submit to basic form');
+
+        if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
+            $this->assertContains('<title>Basic Form Saving</title>', $page->getContent());
+            $this->assertContains('Firstname: Jimmy', $page->getContent());
+        }
+    }
+
+    public function testHtml5FormMethod()
+    {
+        $this->getSession()->visit($this->pathTo('html5_form.html'));
+        $page = $this->getSession()->getPage();
+
+        $page->fillField('first_name', 'Jimmy');
+        $page->fillField('last_name', 'Jones');
+        $page->pressButton('Submit as GET');
+
+        if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
+            $this->assertEquals(
+                $this->pathTo('advanced_form_post.php').'?first_name=Jimmy&last_name=Jones',
+                $this->getSession()->getCurrentUrl()
+            );
+        }
+    }
+
 }

--- a/web-fixtures/html5_form.html
+++ b/web-fixtures/html5_form.html
@@ -10,6 +10,8 @@
         <input name="other_field" type="text" value="not submitted" form="another">
         <input type="submit" value="Submit separate form" form="another">
         <input type="submit" value="Submit in form">
+        <input type="submit" value="Submit to basic form" formaction="basic_form_post.php">
+        <input type="submit" value="Submit as GET" formmethod="GET">
     </form>
     <input name="last_name" type="text" form="test-form" value="not set">
     <button type="submit" form="test-form" name="submit_button" value="test">Submit outside form</button>


### PR DESCRIPTION
Currently MinkBrowserKit does not support the formaction / formmethod html5 attributes that control submission of the form depending on the clicked button. They are [supported by all modern browsers](http://caniuse.com/#search=formaction).

This PR adds tests to go with the bugfix committed to the BrowserKit driver separately.