### PR TITLE
Escape HTML properly when exporting values

### DIFF
--- a/http-kernel-fixtures/404.php
+++ b/http-kernel-fixtures/404.php
@@ -1,3 +1,3 @@
 <?php
 
-$resp = new Symfony\Component\HttpFoundation\Response('Sorry, page not found', 404);
+$resp = new Symfony\Component\HttpFoundation\Response('Sorry, page not found', 404, array('Content-Type' => 'text/plain'));

--- a/http-kernel-fixtures/advanced_form_post.php
+++ b/http-kernel-fixtures/advanced_form_post.php
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 </head>
 <body>
+<pre>
 <?php
 error_reporting(0);
 
@@ -19,7 +20,7 @@ if (isset($POST['select_multiple_numbers']) && false !== strpos($POST['select_mu
 // http://www.w3.org/TR/html401/interact/forms.html#checkbox
 $POST['agreement'] = isset($POST['agreement']) ? 'on' : 'off';
 ksort($POST);
-echo str_replace('>', '', var_export(html_escape_value($POST), true)) . "\n";
+echo html_escape_value(mink_dump($POST)) . "\n";
 if (isset($FILES['about']) && file_exists($FILES['about']->getPathname())) {
     echo html_escape_value($FILES['about']->getClientOriginalName()) . "\n";
     echo html_escape_value(file_get_contents($FILES['about']->getPathname()));
@@ -27,5 +28,6 @@ if (isset($FILES['about']) && file_exists($FILES['about']->getPathname())) {
     echo "no file";
 }
 ?>
+</pre>
 </body>
 </html>

--- a/http-kernel-fixtures/headers.php
+++ b/http-kernel-fixtures/headers.php
@@ -5,6 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
-    <?php print_r($request->server->all()); ?>
+<pre>
+    <?php echo html_escape_value(mink_dump($request->server->all())); ?>
+</pre>
 </body>
 </html>

--- a/http-kernel-fixtures/print_cookies.php
+++ b/http-kernel-fixtures/print_cookies.php
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
+<pre>
     <?php
     $cookies = $request->cookies->all();
     unset($cookies['MOCKSESSID']);
@@ -19,7 +20,8 @@
     foreach ($cookies as $name => $val) {
         $cookies[$name] = (string)$val;
     }
-    echo str_replace(array('>'), '', var_export(html_escape_value($cookies), true));
+    echo html_escape_value(mink_dump($cookies));
     ?>
+</pre>
 </body>
 </html>

--- a/tests/AbstractConfig.php
+++ b/tests/AbstractConfig.php
@@ -16,7 +16,7 @@ abstract class AbstractConfig
     /**
      * Map remote file path.
      *
-     * @param string $file File path.
+     * @param string $file File path
      *
      * @return string
      */
@@ -50,7 +50,7 @@ abstract class AbstractConfig
      * @param string $testCase The name of the TestCase class
      * @param string $test     The name of the test method
      *
-     * @return string|null A message explaining why the test should be skipped, or null to run the test.
+     * @return string|null A message explaining why the test should be skipped, or null to run the test
      */
     public function skipMessage($testCase, $test)
     {

--- a/tests/Basic/CookieTest.php
+++ b/tests/Basic/CookieTest.php
@@ -138,7 +138,7 @@ class CookieTest extends TestCase
 
         $this->getSession()->reset();
         $this->getSession()->visit($this->pathTo('/print_cookies.php'));
-        $this->assertContains("array()", $this->getSession()->getPage()->getText());
+        $this->assertContains('array()', $this->getSession()->getPage()->getText());
     }
 
     public function testHttpOnlyCookieIsDeleted()

--- a/tests/Basic/CookieTest.php
+++ b/tests/Basic/CookieTest.php
@@ -120,25 +120,25 @@ class CookieTest extends TestCase
 
         $this->getSession()->visit($this->pathTo('/print_cookies.php'));
         $this->assertContains(
-            "'client_cookie1' = 'some_val'",
+            'client_cookie1 = `some_val`',
             $this->getSession()->getPage()->getText()
         );
         $this->assertContains(
-            "'client_cookie2' = '123'",
+            'client_cookie2 = `123`',
             $this->getSession()->getPage()->getText()
         );
         $this->assertContains(
-            "_SESS' = ",
+            '_SESS = ',
             $this->getSession()->getPage()->getText()
         );
         $this->assertContains(
-            " 'srvr_cookie' = 'srv_var_is_set'",
+            ' srvr_cookie = `srv_var_is_set`',
             $this->getSession()->getPage()->getText()
         );
 
         $this->getSession()->reset();
         $this->getSession()->visit($this->pathTo('/print_cookies.php'));
-        $this->assertContains('array ( )', $this->getSession()->getPage()->getText());
+        $this->assertContains("array()", $this->getSession()->getPage()->getText());
     }
 
     public function testHttpOnlyCookieIsDeleted()

--- a/tests/Basic/HeaderTest.php
+++ b/tests/Basic/HeaderTest.php
@@ -25,7 +25,7 @@ class HeaderTest extends TestCase
         $this->getSession()->setRequestHeader('Accept-Language', 'fr');
         $this->getSession()->visit($this->pathTo('/headers.php'));
 
-        $this->assertContains('[HTTP_ACCEPT_LANGUAGE] => fr', $this->getSession()->getPage()->getContent());
+        $this->assertContains('HTTP_ACCEPT_LANGUAGE = `fr`', $this->getSession()->getPage()->getContent());
     }
 
     public function testSetUserAgent()
@@ -34,7 +34,7 @@ class HeaderTest extends TestCase
 
         $session->setRequestHeader('user-agent', 'foo bar');
         $session->visit($this->pathTo('/headers.php'));
-        $this->assertContains('[HTTP_USER_AGENT] => foo bar', $session->getPage()->getContent());
+        $this->assertContains('HTTP_USER_AGENT = `foo bar`', $session->getPage()->getContent());
     }
 
     public function testResetHeaders()
@@ -45,7 +45,7 @@ class HeaderTest extends TestCase
         $session->visit($this->pathTo('/headers.php'));
 
         $this->assertContains(
-            '[HTTP_X_MINK_TEST] => test',
+            'HTTP_X_MINK_TEST = `test`',
             $session->getPage()->getContent(),
             'The custom header should be sent',
             true
@@ -55,7 +55,7 @@ class HeaderTest extends TestCase
         $session->visit($this->pathTo('/headers.php'));
 
         $this->assertNotContains(
-            '[HTTP_X_MINK_TEST] => test',
+            'HTTP_X_MINK_TEST = `test`',
             $session->getPage()->getContent(),
             'The custom header should not be sent after resetting',
             true

--- a/tests/Basic/StatusCodeTest.php
+++ b/tests/Basic/StatusCodeTest.php
@@ -17,6 +17,6 @@ class StatusCodeTest extends TestCase
 
         $this->assertEquals($this->pathTo('/404.php'), $this->getSession()->getCurrentUrl());
         $this->assertEquals(404, $this->getSession()->getStatusCode());
-        $this->assertEquals('Sorry, page not found', $this->getSession()->getPage()->getContent());
+        $this->assertContains('Sorry, page not found', $this->getSession()->getPage()->getContent());
     }
 }

--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -204,15 +204,15 @@ class GeneralTest extends TestCase
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
             $out = <<<OUT
-array (
-  'agreement' = 'on',
-  'email' = 'ever.zet@gmail.com',
-  'first_name' = 'Foo &quot;item&quot;',
-  'last_name' = 'Bar',
-  'notes' = 'new notes',
-  'select_number' = '30',
-  'sex' = 'm',
-  'submit' = 'Register',
+array(
+  agreement = `on`,
+  email = `ever.zet@gmail.com`,
+  first_name = `Foo &quot;item&quot;`,
+  last_name = `Bar`,
+  notes = `new notes`,
+  select_number = `30`,
+  sex = `m`,
+  submit = `Register`,
 )
 some_file.txt
 1 uploaded file
@@ -256,13 +256,11 @@ OUT;
         $this->assertNotNull($button);
         $button->press();
 
-        $space = ' ';
         $out = <<<OUT
-  'tags' =$space
-  array (
-    0 = 'tag2',
-    1 = 'one',
-    2 = 'tag3',
+  tags = array(
+    0 = `tag2`,
+    1 = `one`,
+    2 = `tag3`,
   ),
 OUT;
         $this->assertContains($out, $page->getContent());
@@ -278,8 +276,8 @@ OUT;
         $button->press();
 
         $toSearch = array(
-            "'agreement' = 'off',",
-            "'submit' = 'Login',",
+            "agreement = `off`,",
+            "submit = `Login`,",
             'no file',
         );
 
@@ -298,8 +296,8 @@ OUT;
         $page->pressButton('Save');
 
         $toSearch = array(
-            "'textarea' = '',",
-            "'submit' = 'Save',",
+            "textarea = ``,",
+            "submit = `Save`,",
             'no file',
         );
 

--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -98,7 +98,7 @@ class GeneralTest extends TestCase
 
         if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
             $this->assertEquals('Firstname: Konstantin', $webAssert->elementExists('css', '#first')->getText());
-        };
+        }
     }
 
     public function testFormSubmitWithoutButton()
@@ -113,7 +113,7 @@ class GeneralTest extends TestCase
 
         if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
             $this->assertEquals('Firstname: Konstantin', $webAssert->elementExists('css', '#first')->getText());
-        };
+        }
     }
 
     public function testBasicGetForm()
@@ -203,7 +203,7 @@ class GeneralTest extends TestCase
         $button->press();
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
-            $out = <<<OUT
+            $out = <<<'OUT'
 array(
   agreement = `on`,
   email = `ever.zet@gmail.com`,
@@ -256,7 +256,7 @@ OUT;
         $this->assertNotNull($button);
         $button->press();
 
-        $out = <<<OUT
+        $out = <<<'OUT'
   tags = array(
     0 = `tag2`,
     1 = `one`,
@@ -276,8 +276,8 @@ OUT;
         $button->press();
 
         $toSearch = array(
-            "agreement = `off`,",
-            "submit = `Login`,",
+            'agreement = `off`,',
+            'submit = `Login`,',
             'no file',
         );
 
@@ -296,8 +296,8 @@ OUT;
         $page->pressButton('Save');
 
         $toSearch = array(
-            "textarea = ``,",
-            "submit = `Save`,",
+            'textarea = ``,',
+            'submit = `Save`,',
             'no file',
         );
 

--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -24,7 +24,7 @@ class Html5Test extends TestCase
         $page->pressButton('Submit in form');
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
-            $out = <<<OUT
+            $out = <<<'OUT'
   first_name = `John`,
   last_name = `Doe`,
 OUT;
@@ -51,7 +51,7 @@ OUT;
 
         $page->pressButton('Submit in form');
 
-        $out = <<<OUT
+        $out = <<<'OUT'
   sex = `m`,
 OUT;
         $this->assertContains($out, $page->getContent());
@@ -72,7 +72,7 @@ OUT;
         $page->pressButton('Submit outside form');
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
-            $out = <<<OUT
+            $out = <<<'OUT'
   first_name = `John`,
   last_name = `Doe`,
   submit_button = `test`,
@@ -91,7 +91,7 @@ OUT;
         $page->pressButton('Submit separate form');
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
-            $out = <<<OUT
+            $out = <<<'OUT'
   other_field = `hello`,
 OUT;
             $this->assertContains($out, $page->getContent());
@@ -113,7 +113,7 @@ OUT;
 
         $page->pressButton('Submit');
 
-        $out = <<<OUT
+        $out = <<<'OUT'
   color = `#ff00aa`,
   date = `2014-05-19`,
   email = `mink@example.org`,

--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -25,8 +25,8 @@ class Html5Test extends TestCase
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
             $out = <<<OUT
-  'first_name' = 'John',
-  'last_name' = 'Doe',
+  first_name = `John`,
+  last_name = `Doe`,
 OUT;
             $this->assertContains($out, $page->getContent());
             $this->assertNotContains('other_field', $page->getContent());
@@ -52,7 +52,7 @@ OUT;
         $page->pressButton('Submit in form');
 
         $out = <<<OUT
-  'sex' = 'm',
+  sex = `m`,
 OUT;
         $this->assertContains($out, $page->getContent());
     }
@@ -73,9 +73,9 @@ OUT;
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
             $out = <<<OUT
-  'first_name' = 'John',
-  'last_name' = 'Doe',
-  'submit_button' = 'test',
+  first_name = `John`,
+  last_name = `Doe`,
+  submit_button = `test`,
 OUT;
             $this->assertContains($out, $page->getContent());
         }
@@ -92,7 +92,7 @@ OUT;
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
             $out = <<<OUT
-  'other_field' = 'hello',
+  other_field = `hello`,
 OUT;
             $this->assertContains($out, $page->getContent());
             $this->assertNotContains('first_name', $page->getContent());
@@ -114,13 +114,13 @@ OUT;
         $page->pressButton('Submit');
 
         $out = <<<OUT
-  'color' = '#ff00aa',
-  'date' = '2014-05-19',
-  'email' = 'mink@example.org',
-  'number' = '6',
-  'search' = 'mink',
-  'submit_button' = 'Submit',
-  'url' = 'http://mink.behat.org/',
+  color = `#ff00aa`,
+  date = `2014-05-19`,
+  email = `mink@example.org`,
+  number = `6`,
+  search = `mink`,
+  submit_button = `Submit`,
+  url = `http://mink.behat.org/`,
 OUT;
 
         $this->assertContains($out, $page->getContent());

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -39,19 +39,16 @@ class SelectTest extends TestCase
         $this->assertNotNull($button);
         $button->press();
 
-        $space = ' ';
         $out = <<<OUT
-  'agreement' = 'off',
-  'select_multiple_numbers' =$space
-  array (
-    0 = '1',
-    1 = '3',
+  agreement = `off`,
+  select_multiple_numbers = array(
+    0 = `1`,
+    1 = `3`,
   ),
-  'select_multiple_values' =$space
-  array (
-    0 = '2',
+  select_multiple_values = array(
+    0 = `2`,
   ),
-  'select_number' = '30',
+  select_number = `30`,
 OUT;
         $this->assertContains($out, $page->getContent());
     }

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -39,7 +39,7 @@ class SelectTest extends TestCase
         $this->assertNotNull($button);
         $button->press();
 
-        $out = <<<OUT
+        $out = <<<'OUT'
   agreement = `off`,
   select_multiple_numbers = array(
     0 = `1`,

--- a/tests/Js/WindowTest.php
+++ b/tests/Js/WindowTest.php
@@ -62,7 +62,7 @@ class WindowTest extends TestCase
 
         $session->resizeWindow(400, 300);
         $session->wait(1000, 'false');
-        $jsWindowSizeScript = <<<JS
+        $jsWindowSizeScript = <<<'JS'
         (function(){
           var boolSizeCheck = Math.abs(window.outerHeight - 300) <= 100 && Math.abs(window.outerWidth - 400) <= 100;
           if (boolSizeCheck){

--- a/tests/SkippingUnsupportedTestCase.php
+++ b/tests/SkippingUnsupportedTestCase.php
@@ -6,7 +6,7 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 
 if (version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=')) {
     /**
-     * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 5+
+     * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 5+.
      *
      * This code should be moved back to \Behat\Mink\Tests\Driver\TestCase when dropping support for
      * PHP 5.5 and older, as PHPUnit 4 won't be needed anymore.
@@ -26,7 +26,7 @@ if (version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=')) {
     }
 } else {
     /**
-     * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 4
+     * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 4.
      *
      * @internal
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -112,7 +112,7 @@ abstract class TestCase extends SkippingUnsupportedTestCase
     /**
      * Map remote file path.
      *
-     * @param string $file File path.
+     * @param string $file File path
      *
      * @return string
      */

--- a/web-fixtures/404.php
+++ b/web-fixtures/404.php
@@ -1,2 +1,2 @@
-<?php header("HTTP/1.0 404 Not Found") ?>
+<?php header("HTTP/1.0 404 Not Found"); header('Content-Type: text/plain') ?>
 Sorry, page not found

--- a/web-fixtures/advanced_form_post.php
+++ b/web-fixtures/advanced_form_post.php
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 </head>
 <body>
+<pre>
 <?php
 error_reporting(0);
 
@@ -16,7 +17,7 @@ if (isset($_POST['select_multiple_numbers']) && false !== strpos($_POST['select_
 
 $_POST['agreement'] = isset($_POST['agreement']) ? 'on' : 'off';
 ksort($_POST);
-echo str_replace('>', '', var_export(html_escape_value($_POST), true)) . "\n";
+echo html_escape_value(mink_dump($_POST)) . "\n";
 if (isset($_FILES['about']) && file_exists($_FILES['about']['tmp_name'])) {
     echo html_escape_value($_FILES['about']['name']) . "\n";
     echo html_escape_value(file_get_contents($_FILES['about']['tmp_name']));
@@ -24,5 +25,6 @@ if (isset($_FILES['about']) && file_exists($_FILES['about']['tmp_name'])) {
     echo "no file";
 }
 ?>
+</pre>
 </body>
 </html>

--- a/web-fixtures/headers.php
+++ b/web-fixtures/headers.php
@@ -5,6 +5,11 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
-    <?php print_r($_SERVER); ?>
+<pre>
+    <?php
+    require_once 'utils.php';
+    echo html_escape_value(mink_dump($_SERVER));
+    ?>
+</pre>
 </body>
 </html>

--- a/web-fixtures/print_cookies.php
+++ b/web-fixtures/print_cookies.php
@@ -5,9 +5,11 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
+<pre>
     <?php
         require_once 'utils.php';
-        echo str_replace('>', '', var_export(html_escape_value($_COOKIE), true));
+        echo html_escape_value(mink_dump($_COOKIE));
     ?>
+</pre>
 </body>
 </html>

--- a/web-fixtures/utils.php
+++ b/web-fixtures/utils.php
@@ -2,17 +2,7 @@
 
 function html_escape_value($data)
 {
-    if (!is_array($data)) {
-        return htmlspecialchars($data, ENT_QUOTES, 'UTF-8', false);
-    }
-
-    $escapedData = array();
-
-    foreach ($data as $key => $value) {
-        $escapedData[html_escape_value($key)] = html_escape_value($value);
-    }
-
-    return $escapedData;
+    return htmlspecialchars($data, ENT_QUOTES, 'UTF-8');
 }
 
 /**

--- a/web-fixtures/utils.php
+++ b/web-fixtures/utils.php
@@ -14,3 +14,49 @@ function html_escape_value($data)
 
     return $escapedData;
 }
+
+/**
+ * Dumps a value for consumption in tests
+ *
+ * The output format does not use any HTML special chars in boilerplate, to make
+ * it simpler to write assertion on the HTML content generated based on it (no change
+ * in the boilerplate parts during escaping).
+ *
+ * @param mixed $value
+ *
+ * @return string
+ */
+function mink_dump($value)
+{
+    if (null === $value) {
+        return 'null';
+    }
+
+    if (is_string($value)) {
+        return sprintf('`%s`', $value);
+    }
+
+    if (is_bool($value)) {
+        return $value ? 'true' : 'false';
+    }
+
+    if (is_int($value) || is_float($value)) {
+        return var_export($value, true);
+    }
+
+    if (is_array($value)) {
+        if (empty($value)) {
+            return 'array()';
+        }
+
+        $output = array('array(');
+
+        foreach ($value as $k => $v) {
+            $output[] = sprintf('%s = %s,', $k, str_replace("\n", "\n  ", mink_dump($v)));
+        }
+
+        return implode("\n  ", $output)."\n)";
+    }
+
+    return gettype($value); // We don't have full dumping of resource and object, as we don't need them
+}


### PR DESCRIPTION
This avoids cases where we dump ``>`` and ``'`` without escaping. Escaping is now performed cleanly on the whole outputted string.

To simplify assertions, the dumping is performed in a custom format instead of using ``print_r`` and ``var_export``, to avoid using ``'`` and ``>`` in the boilerplate of the dump (or any other char being escaped).

Tests are passing for BrowserKit, Goutte and Zombie. Selenium2Driver fails, but with the same failure than before this change, so it needs to be debugged separately.

This refactoring will help the third-party PhantomJS driver to run the unmodified testsuite (they currently replace all these tests, because PhantomJS gives them the escaped chars when it parses the HTML containing chars which should have been escaped but are not). 