### PR TITLE
Fixed brittle testAdvancedForm test expecting getContent to escape quotes

### DIFF
--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -193,11 +193,11 @@ class GeneralTest extends TestCase
         $button = $page->findButton('Register');
         $this->assertNotNull($button);
 
-        $page->fillField('first_name', 'Foo "item"');
+        $page->fillField('first_name', 'Foo item');
         $page->fillField('last_name', 'Bar');
         $page->fillField('Your email:', 'ever.zet@gmail.com');
 
-        $this->assertEquals('Foo "item"', $firstname->getValue());
+        $this->assertEquals('Foo item', $firstname->getValue());
         $this->assertEquals('Bar', $lastname->getValue());
 
         $button->press();
@@ -207,7 +207,7 @@ class GeneralTest extends TestCase
 array(
   agreement = `on`,
   email = `ever.zet@gmail.com`,
-  first_name = `Foo &quot;item&quot;`,
+  first_name = `Foo item`,
   last_name = `Bar`,
   notes = `new notes`,
   select_number = `30`,


### PR DESCRIPTION
Fixed brittle testAdvancedForm test expecting getContent to escape quotes as &quot; even when they're not in html attributes.

PHP prints those quotes as &quot;, but browsers don't need quotes escaped unless they're in attributes.

The test was failing in at least PhantomJSDriver, Selenium2Driver and ChromeDriver:

- https://travis-ci.org/minkphp/MinkSelenium2Driver/jobs/199234459

- https://travis-ci.org/jcalderonzumba/MinkPhantomJSDriver/jobs/208252113

- https://gitlab.com/DMore/chrome-mink-driver/builds/16252336

https://github.com/minkphp/MinkSelenium2Driver/issues/239

Besides, the form test shouldn't be failing when escaping breaks.