### PR TITLE
Corrected data provider name

### DIFF
--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -54,7 +54,7 @@ OUT;
     }
 
     /**
-     * @dataProvider testElementSelectedStateCheckDataProvider
+     * @dataProvider elementSelectedStateCheckDataProvider
      */
     public function testElementSelectedStateCheck($selectName, $optionValue, $optionText)
     {
@@ -70,7 +70,7 @@ OUT;
         $this->assertTrue($option->isSelected());
     }
 
-    public function testElementSelectedStateCheckDataProvider()
+    public function elementSelectedStateCheckDataProvider()
     {
         return array(
             array('select_number', '30', 'thirty'),


### PR DESCRIPTION
Having data provider methods starting with "test" will make PHPUnit consider them as tests. This has the following effects:
- method is called more then once, depending on the code it might cause issues
- PHPUnit in strict mode will complain that the data provider method does not do any assertions