### PR TITLE
Fix compatibility with PHPUnit 7

### DIFF
--- a/tests/Form/RadioTest.php
+++ b/tests/Form/RadioTest.php
@@ -8,6 +8,8 @@ class RadioTest extends TestCase
 {
     protected function setUp()
     {
+        parent::setUp();
+
         $this->getSession()->visit($this->pathTo('radio.html'));
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,13 +50,13 @@ abstract class TestCase extends SkippingUnsupportedTestCase
         return self::$config;
     }
 
-    protected function checkRequirements()
+    protected function setUp()
     {
         if (null !== $message = self::getConfig()->skipMessage(get_class($this), $this->getName(false))) {
             $this->markTestSkipped($message);
         }
 
-        parent::checkRequirements();
+        parent::setUp();
     }
 
     protected function tearDown()


### PR DESCRIPTION
`checkRequirements` was not an official extension point, and became private in PHPUnit 7