### PR TITLE
Fix legacy cookie defaults deprecations

### DIFF
--- a/http-kernel-fixtures/cookie_page1.php
+++ b/http-kernel-fixtures/cookie_page1.php
@@ -1,6 +1,10 @@
 <?php
     $resp = new Symfony\Component\HttpFoundation\Response();
-    $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set', 0, '/');
+    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+        $cook = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set', 0, '/');
+    } else {
+        $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set', 0, '/');
+    }
     $resp->headers->setCookie($cook);
 ?>
 <!doctype html public "-//w3c//dtd xhtml 1.1//en" "http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd">

--- a/http-kernel-fixtures/cookie_page3.php
+++ b/http-kernel-fixtures/cookie_page3.php
@@ -2,7 +2,11 @@
 
 $hasCookie = $request->cookies->has('foo');
 $resp = new Symfony\Component\HttpFoundation\Response();
-$cook = new Symfony\Component\HttpFoundation\Cookie('foo', 'bar');
+if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+    $cook = Symfony\Component\HttpFoundation\Cookie::create('foo', 'bar');
+} else {
+    $cook = new Symfony\Component\HttpFoundation\Cookie('foo', 'bar');
+}
 $resp->headers->setCookie($cook);
 
 ?>

--- a/http-kernel-fixtures/issue140.php
+++ b/http-kernel-fixtures/issue140.php
@@ -7,7 +7,11 @@
 <?php
 if ($request->isMethod('POST')) {
     $resp = new Symfony\Component\HttpFoundation\Response();
-    $cook = new Symfony\Component\HttpFoundation\Cookie('tc', $request->request->get('cookie_value'));
+    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+        $cook = Symfony\Component\HttpFoundation\Cookie::create('tc', $request->request->get('cookie_value'));
+    } else {
+        $cook = new Symfony\Component\HttpFoundation\Cookie('tc', $request->request->get('cookie_value'));
+    }
     $resp->headers->setCookie($cook);
 } elseif ($request->query->has('show_value')) {
     echo html_escape_value($request->cookies->get('tc'));

--- a/http-kernel-fixtures/sub-folder/cookie_page1.php
+++ b/http-kernel-fixtures/sub-folder/cookie_page1.php
@@ -1,7 +1,11 @@
 <?php
     $requestUri = $request->server->get('REQUEST_URI');
     $resp = new Symfony\Component\HttpFoundation\Response();
-    $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
+    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+        $cook = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
+    } else {
+        $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
+    }
     $resp->headers->setCookie($cook);
 ?>
 <!doctype html public "-//w3c//dtd xhtml 1.1//en" "http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd">

--- a/src/FixturesKernel.php
+++ b/src/FixturesKernel.php
@@ -74,7 +74,13 @@ class FixturesKernel implements HttpKernelInterface
 
             $params = session_get_cookie_params();
 
-            $response->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
+            if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+                $cookie = Cookie::create($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+            } else {
+                $cookie = new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+            }
+
+            $response->headers->setCookie($cookie);
         }
     }
 }


### PR DESCRIPTION
Fixes deprecation from latest Symfony version
```
The default value of the "$secure" and "$samesite" arguments of "Symfony\Component\HttpFoundation\Cookie::__construct"'s constructor will respectively change from "false" to "null" and from "null" to "lax" in Symfony 5.0, you should define their values explicitly or use "Cookie::create()" instead.
```
Supports both current (constructor) version and suggested `Cookie::create` factory.

Since supported PHP version is 5.3.x+, couldn't use `Cookie::class` constant so instead used string of class name.