### PR TITLE
making testKeyboardEvents w3c compatible

### DIFF
--- a/web-fixtures/js_test.html
+++ b/web-fixtures/js_test.html
@@ -26,9 +26,7 @@
         <div id="mouseover-detector">no mouse action detected</div>
         <div id="invisible" style="display: none">invisible man</div>
         <input id="focus-blur-detector" type="text" value="no action detected"/>
-        <input class="input first" type="text" value="" />
-        <input class="input second" type="text" value="" />
-        <input class="input third" type="text" value="" />
+        <input class="input" type="text" value="" />
         <div class="text-event"></div>
     </div>
 
@@ -72,16 +70,15 @@
                 $(this).text('mouse overed');
             });
 
-            $('.elements input.input.first').keydown(function(ev) {
-                $('.text-event').text('key downed:' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
-            });
-
-            $('.elements input.input.second').keypress(function(ev) {
-                $('.text-event').text('key pressed:' + ev.which + ' / ' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
-            });
-
-            $('.elements input.input.third').keyup(function(ev) {
-                $('.text-event').text('key upped:' + ev.which + ' / ' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
+            $('.elements input.input').bind('keydown keypress keyup', function(ev) {
+                console.log('event=%s keyCode=%s altKey=%s ctrlKey=%s shiftKey=%s metaKey=%s', ev.type, ev.keyCode, ev.altKey, ev.ctrlKey, ev.shiftKey, ev.metaKey);
+                $('.text-event').append([
+                    'event=' + ev.type,
+                    // chrome and firefox are returning different values on keypress
+                    'keyCode=' + (ev.keyCode || ev.charCode),
+                    'modifier=' + ((ev.altKey * 1) + ' / ' + (ev.ctrlKey * 1) + ' / ' + (ev.shiftKey * 1) + ' / ' + (ev.metaKey * 1)),
+                    null
+                ].join(';') + "<br/>\n");
             });
 
             $( "#draggable" ).draggable();


### PR DESCRIPTION
To make Mink Drivers more compatible W3C driver [specifications](https://www.w3.org/TR/webdriver/) need to adjust some testcases e.g.: `testKeyboardEvents`
https://github.com/minkphp/driver-testsuite/blob/7abcb4243ed8a1d9c53aa03c8abb0c29c7e81e9e/tests/Js/EventsTest.php#L91-L109
because W3C does not allow sending separate actions like keyUp, keyDown, keyPress
https://www.w3.org/TR/webdriver/#dfn-element-send-keys

I'm trying to replace `instaclick/php-webdriver` with `facebook/php-webdriver` for MinkSelenium2Driver ([work in progress](https://github.com/minkphp/MinkSelenium2Driver/compare/master...oleg-andreyev:master))

Changes are tested againts `selenium/standalone-chrome:latest` and `selenium/standalone-firefox:2.53.1`

`MinkZombieDriver` will not pass this tests, because zombie.js does not implement `KeyboardEvent` as described https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent 
https://github.com/assaf/zombie/issues/275#issuecomment-5540968