### PR TITLE
Remove syntax erroring javascript

### DIFF
--- a/tests/Js/JavascriptEvaluationTest.php
+++ b/tests/Js/JavascriptEvaluationTest.php
@@ -60,8 +60,6 @@ class JavascriptEvaluationTest extends TestCase
         return array(
             array('document.querySelector("h1").textContent = "Hello world"'),
             array('document.querySelector("h1").textContent = "Hello world";'),
-            array('function () {document.querySelector("h1").textContent = "Hello world";}()'),
-            array('function () {document.querySelector("h1").textContent = "Hello world";}();'),
             array('(function () {document.querySelector("h1").textContent = "Hello world";})()'),
             array('(function () {document.querySelector("h1").textContent = "Hello world";})();'),
         );


### PR DESCRIPTION
...because ```function () {document.querySelector("h1").textContent = "Hello world";}()```
and
```function () {document.querySelector("h1").textContent = "Hello world";}();```
are throwing a SyntaxError which leads to failing tests at least when executed with chrome web driver.

![image](https://user-images.githubusercontent.com/1651297/54868388-3f0baa00-4d8c-11e9-9289-019d28ff2d25.png)
