### PR TITLE
Use canonical path for file input value

### DIFF
--- a/tests/Js/ChangeEventTest.php
+++ b/tests/Js/ChangeEventTest.php
@@ -60,8 +60,8 @@ class ChangeEventTest extends TestCase
 
     public function setValueChangeEventDataProvider()
     {
-        $file1 = __DIR__ . '/../../web-fixtures/file1.txt';
-        $file2 = __DIR__ . '/../../web-fixtures/file2.txt';
+        $file1 = realpath(__DIR__ . '/../../web-fixtures/file1.txt');
+        $file2 = realpath(__DIR__ . '/../../web-fixtures/file2.txt');
 
         return array(
             'input default' => array('the-input-default', 'from empty', 'from existing'),


### PR DESCRIPTION
Also see #26 and #9 

Executing the test suite with panther gives following result:
```
There was 1 error:

1) Behat\Mink\Tests\Driver\Custom\Js\ChangeEventTest::testSetValueChangeEvent with data set "file" ('the-file', '/var/www/html/vendor/mink/dri...e1.txt', '/var/www/html/vendor/mink/dri...e2.txt')
Facebook\WebDriver\Exception\UnknownServerException: unknown error: path is not canonical: /var/www/html/vendor/mink/driver-testsuite/tests/Js/../../web-fixtures/file1.txt
```