### PR TITLE
Fix condition for safePageWait in GeneralTest::testAdvancedForm

### DIFF
--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -202,7 +202,7 @@ class GeneralTest extends TestCase
 
         $button->press();
 
-        if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
+        if ($this->safePageWait(5000, 'document.getElementsByTagName("title") === "Advanced form save"')) {
             $out = <<<'OUT'
 array(
   agreement = `on`,


### PR DESCRIPTION
...cause both pages have a title and we are on the new/submitted page if title is "Advanced form save".

Form page: https://github.com/minkphp/driver-testsuite/blob/d208035ccc5eaf4f1def0299a1979c1851a9a0fb/web-fixtures/advanced_form.html#L4
Submitted page: https://github.com/minkphp/driver-testsuite/blob/d208035ccc5eaf4f1def0299a1979c1851a9a0fb/web-fixtures/advanced_form_post.php#L4

Edit: Added file preview.