### PR TITLE
Add PHPUnit as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The testsuite of a driver should be based as follow:
     "require": {
         "behat/mink": "~1.7"
     },
-    
+
     "require-dev": {
         "mink/driver-testsuite": "dev-master"
     },
@@ -110,6 +110,7 @@ To stop the server at the end of tests, cancel the command.
 > in the PATH is a different one, use the `MINK_PHP_BIN` env variable to select a different PHP runtime.
 
 You can now run tests for your driver with `phpunit`.
+This package installs PHPUnit as a dependency to ensure that a version of PHPUnit compatible with the testsuite is used.
 
 Adding Driver-specific Tests
 ----------------------------

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": ">=5.3",
         "behat/mink":  "~1.7",
-        "symfony/phpunit-bridge": "^4.2"
+        "symfony/phpunit-bridge": "^4.2",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.18"
     },
     "require-dev": {
         "symfony/http-kernel": "^2.7 || ^3.2 || ^4.0"


### PR DESCRIPTION
Until now, our CI config relies on the simple-phpunit script of the symfony/phpunit-bridge to install a version of PHPUnit compatible with the PHP version. But this has one drawback: the bridge could be updated to select new PHPUnit versions before our testsuite is compatible.
So we now use a composer dependency directly.

Forcing a PHPUnit version in the bridge would be hard, as we cannot have a single version supported by all PHP versions. That's why this solution was selected.