### PR TITLE
Enable upgrade to PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 phpunit.xml
 composer.lock
 vendor
+Dockerfile
+docker-compose.yml
+Makefile

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,15 @@
     ],
 
     "require": {
-        "php": ">=5.3",
+        "php": ">=7.3",
         "behat/mink":  "~1.7",
-        "symfony/phpunit-bridge": "^4.2",
-        "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.18"
+        "symfony/phpunit-bridge": "~5.2",
+        "phpunit/phpunit": "~8.5 || ~9.5",
+        "symfony/browser-kit":  "~5.2"
     },
     "require-dev": {
-        "symfony/http-kernel": "^2.7 || ^3.2 || ^4.0"
+        "symfony/http-kernel": "~5.2",
+        "symfony/http-client": "~5.2"
     },
 
     "bin": [

--- a/tests/Basic/BasicAuthTest.php
+++ b/tests/Basic/BasicAuthTest.php
@@ -17,7 +17,7 @@ class BasicAuthTest extends TestCase
 
         $session->visit($this->pathTo('/basic_auth.php'));
 
-        $this->assertContains($pageText, $session->getPage()->getContent());
+        $this->assertStringContainsString($pageText, $session->getPage()->getContent());
     }
 
     public function setBasicAuthDataProvider()
@@ -36,13 +36,13 @@ class BasicAuthTest extends TestCase
 
         $session->visit($this->pathTo('/basic_auth.php'));
 
-        $this->assertContains('is authenticated', $session->getPage()->getContent());
+        $this->assertStringContainsString('is authenticated', $session->getPage()->getContent());
 
         $session->setBasicAuth(false);
 
         $session->visit($this->pathTo('/headers.php'));
 
-        $this->assertNotContains('PHP_AUTH_USER', $session->getPage()->getContent());
+        $this->assertStringNotContainsString('PHP_AUTH_USER', $session->getPage()->getContent());
     }
 
     public function testResetWithBasicAuth()
@@ -53,12 +53,12 @@ class BasicAuthTest extends TestCase
 
         $session->visit($this->pathTo('/basic_auth.php'));
 
-        $this->assertContains('is authenticated', $session->getPage()->getContent());
+        $this->assertStringContainsString('is authenticated', $session->getPage()->getContent());
 
         $session->reset();
 
         $session->visit($this->pathTo('/headers.php'));
 
-        $this->assertNotContains('PHP_AUTH_USER', $session->getPage()->getContent());
+        $this->assertStringNotContainsString('PHP_AUTH_USER', $session->getPage()->getContent());
     }
 }

--- a/tests/Basic/ContentTest.php
+++ b/tests/Basic/ContentTest.php
@@ -59,7 +59,7 @@ class ContentTest extends TestCase
     public function testJson()
     {
         $this->getSession()->visit($this->pathTo('/json.php'));
-        $this->assertContains(
+        $this->assertStringContainsString(
             '{"key1":"val1","key2":234,"key3":[1,2,3]}',
             $this->getSession()->getPage()->getContent()
         );
@@ -76,8 +76,8 @@ class ContentTest extends TestCase
         $input = $webAssert->elementExists('css', 'input');
 
         $expectedHtml = '<span custom-attr="&amp;">some text</span>';
-        $this->assertContains($expectedHtml, $page->getHtml(), '.innerHTML is returned as-is');
-        $this->assertContains($expectedHtml, $page->getContent(), '.outerHTML is returned as-is');
+        $this->assertStringContainsString($expectedHtml, $page->getHtml(), '.innerHTML is returned as-is');
+        $this->assertStringContainsString($expectedHtml, $page->getContent(), '.outerHTML is returned as-is');
 
         $this->assertEquals('&', $span->getAttribute('custom-attr'), '.getAttribute value is decoded');
         $this->assertEquals('&', $input->getAttribute('value'), '.getAttribute value is decoded');

--- a/tests/Basic/CookieTest.php
+++ b/tests/Basic/CookieTest.php
@@ -26,25 +26,25 @@ class CookieTest extends TestCase
     public function testCookie()
     {
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
-        $this->assertContains('Previous cookie: NO', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $this->getSession()->getPage()->getText());
         $this->assertNull($this->getSession()->getCookie('srvr_cookie'));
 
         $this->getSession()->setCookie('srvr_cookie', 'client cookie set');
         $this->getSession()->reload();
-        $this->assertContains('Previous cookie: client cookie set', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: client cookie set', $this->getSession()->getPage()->getText());
         $this->assertEquals('client cookie set', $this->getSession()->getCookie('srvr_cookie'));
 
         $this->getSession()->setCookie('srvr_cookie', null);
         $this->getSession()->reload();
-        $this->assertContains('Previous cookie: NO', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $this->getSession()->getPage()->getText());
 
         $this->getSession()->visit($this->pathTo('/cookie_page1.php'));
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
 
-        $this->assertContains('Previous cookie: srv_var_is_set', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: srv_var_is_set', $this->getSession()->getPage()->getText());
         $this->getSession()->setCookie('srvr_cookie', null);
         $this->getSession()->reload();
-        $this->assertContains('Previous cookie: NO', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $this->getSession()->getPage()->getText());
     }
 
     public function testCookieWithSemicolon()
@@ -53,7 +53,7 @@ class CookieTest extends TestCase
         $this->getSession()->setCookie('srvr_cookie', 'foo;bar;baz');
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
         $this->assertEquals('foo;bar;baz', $this->getSession()->getCookie('srvr_cookie'));
-        $this->assertContains('Previous cookie: foo;bar;baz', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: foo;bar;baz', $this->getSession()->getPage()->getText());
     }
 
     /**
@@ -64,17 +64,17 @@ class CookieTest extends TestCase
         // start clean
         $session = $this->getSession();
         $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
-        $this->assertContains('Previous cookie: NO', $session->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $session->getPage()->getText());
 
         // cookie from root path is accessible in sub-folder
         $session->visit($this->pathTo('/cookie_page1.php'));
         $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
-        $this->assertContains('Previous cookie: srv_var_is_set', $session->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: srv_var_is_set', $session->getPage()->getText());
 
         // cookie from sub-folder overrides cookie from root path
         $session->visit($this->pathTo('/sub-folder/cookie_page1.php'));
         $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
-        $this->assertContains('Previous cookie: srv_var_is_set_sub_folder', $session->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: srv_var_is_set_sub_folder', $session->getPage()->getText());
 
         if ($cookieRemovalMode == 'session_reset') {
             $session->reset();
@@ -84,7 +84,7 @@ class CookieTest extends TestCase
 
         // cookie is removed from all paths
         $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
-        $this->assertContains('Previous cookie: NO', $session->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $session->getPage()->getText());
     }
 
     public function cookieWithPathsDataProvider()
@@ -99,19 +99,19 @@ class CookieTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/cookie_page1.php'));
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
-        $this->assertContains('Previous cookie: srv_var_is_set', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: srv_var_is_set', $this->getSession()->getPage()->getText());
 
         $this->getSession()->reset();
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
 
-        $this->assertContains('Previous cookie: NO', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $this->getSession()->getPage()->getText());
 
         $this->getSession()->setCookie('srvr_cookie', 'test_cookie');
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
-        $this->assertContains('Previous cookie: test_cookie', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: test_cookie', $this->getSession()->getPage()->getText());
         $this->getSession()->reset();
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
-        $this->assertContains('Previous cookie: NO', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('Previous cookie: NO', $this->getSession()->getPage()->getText());
 
         $this->getSession()->setCookie('client_cookie1', 'some_val');
         $this->getSession()->setCookie('client_cookie2', '123');
@@ -119,26 +119,26 @@ class CookieTest extends TestCase
         $this->getSession()->visit($this->pathTo('/cookie_page1.php'));
 
         $this->getSession()->visit($this->pathTo('/print_cookies.php'));
-        $this->assertContains(
+        $this->assertStringContainsString(
             'client_cookie1 = `some_val`',
             $this->getSession()->getPage()->getText()
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'client_cookie2 = `123`',
             $this->getSession()->getPage()->getText()
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '_SESS = ',
             $this->getSession()->getPage()->getText()
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             ' srvr_cookie = `srv_var_is_set`',
             $this->getSession()->getPage()->getText()
         );
 
         $this->getSession()->reset();
         $this->getSession()->visit($this->pathTo('/print_cookies.php'));
-        $this->assertContains('array()', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('array()', $this->getSession()->getPage()->getText());
     }
 
     public function testHttpOnlyCookieIsDeleted()

--- a/tests/Basic/ErrorHandlingTest.php
+++ b/tests/Basic/ErrorHandlingTest.php
@@ -19,7 +19,7 @@ class ErrorHandlingTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/500.php'));
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Sorry, a server error happened',
             $this->getSession()->getPage()->getContent(),
             'Drivers allow loading pages with a 500 status code'

--- a/tests/Basic/HeaderTest.php
+++ b/tests/Basic/HeaderTest.php
@@ -25,7 +25,7 @@ class HeaderTest extends TestCase
         $this->getSession()->setRequestHeader('Accept-Language', 'fr');
         $this->getSession()->visit($this->pathTo('/headers.php'));
 
-        $this->assertContains('HTTP_ACCEPT_LANGUAGE = `fr`', $this->getSession()->getPage()->getContent());
+        $this->assertStringContainsString('HTTP_ACCEPT_LANGUAGE = `fr`', $this->getSession()->getPage()->getContent());
     }
 
     public function testSetUserAgent()
@@ -34,7 +34,7 @@ class HeaderTest extends TestCase
 
         $session->setRequestHeader('user-agent', 'foo bar');
         $session->visit($this->pathTo('/headers.php'));
-        $this->assertContains('HTTP_USER_AGENT = `foo bar`', $session->getPage()->getContent());
+        $this->assertStringContainsString('HTTP_USER_AGENT = `foo bar`', $session->getPage()->getContent());
     }
 
     public function testResetHeaders()
@@ -44,7 +44,7 @@ class HeaderTest extends TestCase
         $session->setRequestHeader('X-Mink-Test', 'test');
         $session->visit($this->pathTo('/headers.php'));
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'HTTP_X_MINK_TEST = `test`',
             $session->getPage()->getContent(),
             'The custom header should be sent',
@@ -54,7 +54,7 @@ class HeaderTest extends TestCase
         $session->reset();
         $session->visit($this->pathTo('/headers.php'));
 
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             'HTTP_X_MINK_TEST = `test`',
             $session->getPage()->getContent(),
             'The custom header should not be sent after resetting',

--- a/tests/Basic/NavigationTest.php
+++ b/tests/Basic/NavigationTest.php
@@ -41,7 +41,11 @@ class NavigationTest extends TestCase
         $link = $page->findLink('Redirect me to');
 
         $this->assertNotNull($link);
-        $this->assertRegExp('/redirector\.php$/', $link->getAttribute('href'));
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/redirector\.php$/', $link->getAttribute('href'));
+        } elseif (method_exists($this, 'assertRegExp')) {
+            $this->assertRegExp('/redirector\.php$/', $link->getAttribute('href'));
+        }
         $link->click();
 
         $this->assertEquals($this->pathTo('/redirect_destination.html'), $this->getSession()->getCurrentUrl());
@@ -51,7 +55,11 @@ class NavigationTest extends TestCase
         $link = $page->findLink('basic form image');
 
         $this->assertNotNull($link);
-        $this->assertRegExp('/basic_form\.html$/', $link->getAttribute('href'));
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/basic_form\.html$/', $link->getAttribute('href'));
+        } elseif (method_exists($this, 'assertRegExp')) {
+            $this->assertRegExp('/basic_form\.html$/', $link->getAttribute('href'));
+        }
         $link->click();
 
         $this->assertEquals($this->pathTo('/basic_form.html'), $this->getSession()->getCurrentUrl());
@@ -61,7 +69,11 @@ class NavigationTest extends TestCase
         $link = $page->findLink('Link with a ');
 
         $this->assertNotNull($link);
-        $this->assertRegExp('/links\.html\?quoted$/', $link->getAttribute('href'));
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/links\.html\?quoted$/', $link->getAttribute('href'));
+        } elseif (method_exists($this, 'assertRegExp')) {
+            $this->assertRegExp('/links\.html\?quoted$/', $link->getAttribute('href'));
+        }
         $link->click();
 
         $this->assertEquals($this->pathTo('/links.html?quoted'), $this->getSession()->getCurrentUrl());

--- a/tests/Basic/ScreenshotTest.php
+++ b/tests/Basic/ScreenshotTest.php
@@ -16,7 +16,7 @@ class ScreenshotTest extends TestCase
 
         $screenShot = $this->getSession()->getScreenshot();
 
-        $this->assertInternalType('string', $screenShot);
+        $this->assertIsString($screenShot);
         $this->assertFalse(base64_decode($screenShot, true), 'The returned screenshot should not be base64-encoded');
 
         $img = imagecreatefromstring($screenShot);

--- a/tests/Basic/StatusCodeTest.php
+++ b/tests/Basic/StatusCodeTest.php
@@ -17,6 +17,6 @@ class StatusCodeTest extends TestCase
 
         $this->assertEquals($this->pathTo('/404.php'), $this->getSession()->getCurrentUrl());
         $this->assertEquals(404, $this->getSession()->getStatusCode());
-        $this->assertContains('Sorry, page not found', $this->getSession()->getPage()->getContent());
+        $this->assertStringContainsString('Sorry, page not found', $this->getSession()->getPage()->getContent());
     }
 }

--- a/tests/Basic/TraversingTest.php
+++ b/tests/Basic/TraversingTest.php
@@ -122,7 +122,11 @@ class TraversingTest extends TestCase
         $subUrl = $subDivs[2]->findLink('some deep url');
         $this->assertNotNull($subUrl);
 
-        $this->assertRegExp('/some_url$/', $subUrl->getAttribute('href'));
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/some_url$/', $subUrl->getAttribute('href'));
+        } elseif (method_exists($this, 'assertRegExp')) {
+            $this->assertRegExp('/some_url$/', $subUrl->getAttribute('href'));
+        }
         $this->assertEquals('some deep url', $subUrl->getText());
         $this->assertEquals('some <strong>deep</strong> url', $subUrl->getHtml());
 

--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -142,7 +142,7 @@ class GeneralTest extends TestCase
 
         $page->pressButton('Register');
 
-        $this->assertContains('no file', $page->getContent());
+        $this->assertStringContainsString('no file', $page->getContent());
 
         $this->getSession()->visit($this->pathTo('/advanced_form.html'));
 
@@ -217,7 +217,7 @@ array(
 some_file.txt
 1 uploaded file
 OUT;
-            $this->assertContains($out, $page->getContent());
+            $this->assertStringContainsString($out, $page->getContent());
         }
     }
 
@@ -303,7 +303,7 @@ OUT;
     2 = `tag3`,
   ),
 OUT;
-        $this->assertContains($out, $page->getContent());
+        $this->assertStringContainsString($out, $page->getContent());
     }
 
     public function testAdvancedFormSecondSubmit()
@@ -324,7 +324,7 @@ OUT;
         $pageContent = $page->getContent();
 
         foreach ($toSearch as $searchString) {
-            $this->assertContains($searchString, $pageContent);
+            $this->assertStringContainsString($searchString, $pageContent);
         }
     }
 
@@ -344,7 +344,7 @@ OUT;
         $pageContent = $page->getContent();
 
         foreach ($toSearch as $searchString) {
-            $this->assertContains($searchString, $pageContent);
+            $this->assertStringContainsString($searchString, $pageContent);
         }
     }
 }

--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -28,8 +28,8 @@ class Html5Test extends TestCase
   first_name = `John`,
   last_name = `Doe`,
 OUT;
-            $this->assertContains($out, $page->getContent());
-            $this->assertNotContains('other_field', $page->getContent());
+            $this->assertStringContainsString($out, $page->getContent());
+            $this->assertStringNotContainsString('other_field', $page->getContent());
         }
     }
 
@@ -54,7 +54,7 @@ OUT;
         $out = <<<'OUT'
   sex = `m`,
 OUT;
-        $this->assertContains($out, $page->getContent());
+        $this->assertStringContainsString($out, $page->getContent());
     }
 
     public function testHtml5FormButtonAttribute()
@@ -77,7 +77,7 @@ OUT;
   last_name = `Doe`,
   submit_button = `test`,
 OUT;
-            $this->assertContains($out, $page->getContent());
+            $this->assertStringContainsString($out, $page->getContent());
         }
     }
 
@@ -94,8 +94,8 @@ OUT;
             $out = <<<'OUT'
   other_field = `hello`,
 OUT;
-            $this->assertContains($out, $page->getContent());
-            $this->assertNotContains('first_name', $page->getContent());
+            $this->assertStringContainsString($out, $page->getContent());
+            $this->assertStringNotContainsString('first_name', $page->getContent());
         }
     }
 
@@ -125,7 +125,7 @@ OUT;
   url = `http://mink.behat.org/`,
 OUT;
 
-        $this->assertContains($out, $page->getContent());
+        $this->assertStringContainsString($out, $page->getContent());
     }
 
     public function testHtml5FormAction()
@@ -137,8 +137,8 @@ OUT;
         $page->pressButton('Submit to basic form');
 
         if ($this->safePageWait(5000, 'document.getElementsByTagName("title") !== null')) {
-            $this->assertContains('<title>Basic Form Saving</title>', $page->getContent());
-            $this->assertContains('Firstname: Jimmy', $page->getContent());
+            $this->assertStringContainsString('<title>Basic Form Saving</title>', $page->getContent());
+            $this->assertStringContainsString('Firstname: Jimmy', $page->getContent());
         }
     }
 

--- a/tests/Form/RadioTest.php
+++ b/tests/Form/RadioTest.php
@@ -6,7 +6,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 class RadioTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -57,7 +57,7 @@ class SelectTest extends TestCase
   ),
   select_number = `30`,
 OUT;
-        $this->assertContains($out, $page->getContent());
+        $this->assertStringContainsString($out, $page->getContent());
     }
 
     /**

--- a/tests/Js/JavascriptTest.php
+++ b/tests/Js/JavascriptTest.php
@@ -37,6 +37,6 @@ class JavascriptTest extends TestCase
         $this->getSession()->getPage()->pressButton('Créer un compte');
         $this->getSession()->wait(5000, '$("#panel").text() != ""');
 
-        $this->assertContains('OH AIH!', $this->getSession()->getPage()->getText());
+        $this->assertStringContainsString('OH AIH!', $this->getSession()->getPage()->getText());
     }
 }

--- a/tests/SkippingUnsupportedTestCase.php
+++ b/tests/SkippingUnsupportedTestCase.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Behat\Mink\Tests\Driver;
 
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Exception;
+use Throwable;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use PHPUnit\Runner\Version;
+use function version_compare;
 
 if (class_exists('PHPUnit\Runner\Version') && version_compare(Version::id(), '6.0.0', '>=')) {
     /**
@@ -17,7 +22,7 @@ if (class_exists('PHPUnit\Runner\Version') && version_compare(Version::id(), '6.
      */
     class SkippingUnsupportedTestCase extends BaseTestCase
     {
-        protected function onNotSuccessfulTest(\Throwable $e)
+        protected function onNotSuccessfulTest(Throwable $e): void
         {
             if ($e instanceof UnsupportedDriverActionException) {
                 $this->markTestSkipped($e->getMessage());
@@ -26,15 +31,15 @@ if (class_exists('PHPUnit\Runner\Version') && version_compare(Version::id(), '6.
             parent::onNotSuccessfulTest($e);
         }
     }
-} elseif (version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=')) {
+} elseif (version_compare(Version::id(), '5.0.0', '>=')) {
     /**
      * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 5.
      *
      * @internal
      */
-    class SkippingUnsupportedTestCase extends \PHPUnit_Framework_TestCase
+    class SkippingUnsupportedTestCase extends BaseTestCase
     {
-        protected function onNotSuccessfulTest($e)
+        protected function onNotSuccessfulTest($e): void
         {
             if ($e instanceof UnsupportedDriverActionException) {
                 $this->markTestSkipped($e->getMessage());
@@ -49,9 +54,9 @@ if (class_exists('PHPUnit\Runner\Version') && version_compare(Version::id(), '6.
      *
      * @internal
      */
-    class SkippingUnsupportedTestCase extends \PHPUnit_Framework_TestCase
+    class SkippingUnsupportedTestCase extends BaseTestCase
     {
-        protected function onNotSuccessfulTest(\Exception $e)
+        protected function onNotSuccessfulTest(Exception $e): void
         {
             if ($e instanceof UnsupportedDriverActionException) {
                 $this->markTestSkipped($e->getMessage());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Behat\Mink\Tests\Driver;
 
 use Behat\Mink\Exception\UnsupportedDriverActionException;
@@ -24,7 +26,7 @@ abstract class TestCase extends SkippingUnsupportedTestCase
     /**
      * Initializes the test case.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (null === self::$mink) {
             $session = new Session(self::getConfig()->createDriver());
@@ -50,7 +52,7 @@ abstract class TestCase extends SkippingUnsupportedTestCase
         return self::$config;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (null !== $message = self::getConfig()->skipMessage(get_class($this), $this->getName(false))) {
             $this->markTestSkipped($message);
@@ -59,7 +61,7 @@ abstract class TestCase extends SkippingUnsupportedTestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (null !== self::$mink) {
             self::$mink->resetSessions();


### PR DESCRIPTION
This breaks backward compatibility which seems is not avoidable. Enable upgrade to PHP 8.0, Symfony 5.2, PHPUnit 8.5 and 9.5.