### PR TITLE
Add test for removal of cookie in a subpath

### DIFF
--- a/http-kernel-fixtures/sub-folder/cookie_page4.php
+++ b/http-kernel-fixtures/sub-folder/cookie_page4.php
@@ -1,0 +1,20 @@
+<?php
+    $resp = new Symfony\Component\HttpFoundation\Response();
+    $cookiePath = dirname($request->server->get('REQUEST_URI')) . '/';
+    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+        $cookie = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set', 0, $cookiePath);
+    } else {
+        $cookie = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set', 0, $cookiePath);
+    }
+    $resp->headers->setCookie($cookie);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Basic page with cookie set in sub-directory from server side</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+    Basic page with cookie set in sub-directory from server side
+</body>
+</html>

--- a/tests/Basic/CookieTest.php
+++ b/tests/Basic/CookieTest.php
@@ -95,6 +95,42 @@ class CookieTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider cookieWithPathsDataProvider
+     */
+    public function testCookieInSubPath($cookieRemovalMode)
+    {
+        // Start clean.
+        // The cookie is set when viewing the page.
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
+        $this->assertContains('Previous cookie: NO', $session->getPage()->getText());
+
+        $session->visit($this->pathTo('/sub-folder/cookie_page4.php'));
+
+        // On the next load, the cookie has been set.
+        $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
+        $this->assertContains('Previous cookie: srv_var_is_set', $session->getPage()->getText());
+
+        if ($cookieRemovalMode == 'session_reset') {
+            $session->reset();
+        } elseif ($cookieRemovalMode == 'cookie_delete') {
+            $session->setCookie('srvr_cookie', null);
+        }
+
+        // Cookie is removed>
+        $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
+        $this->assertContains('Previous cookie: NO', $session->getPage()->getText());
+    }
+
+    public function cookieInSubPathProvider()
+    {
+        return array(
+            array('session_reset'),
+            array('cookie_delete'),
+        );
+    }
+
     public function testReset()
     {
         $this->getSession()->visit($this->pathTo('/cookie_page1.php'));

--- a/web-fixtures/sub-folder/cookie_page4.php
+++ b/web-fixtures/sub-folder/cookie_page4.php
@@ -1,0 +1,18 @@
+<?php
+if (!isset($cookieValue)) {
+    $cookieValue = 'srv_var_is_set';
+}
+
+$cookiePath = dirname($_SERVER['REQUEST_URI']) . '/';
+setcookie('srvr_cookie', $cookieValue, null, $cookiePath);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Basic page with cookie set in sub-directory from server side</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+    Basic page with cookie set in sub-directory from server side
+</body>
+</html>


### PR DESCRIPTION
The previous tests only ensured that a root cookie removed in a
subfolder was applied to the child folder. It did not check that a
cookie set only in a folder is correctly deleted.

This patch adds a new test for a cookie which is set with a $path
argument other than /.

See https://github.com/minkphp/MinkBrowserKitDriver/pull/157 for an example of this issue.