### PR TITLE
Fix: Use correct data type when calling method setcookie()

### DIFF
--- a/web-fixtures/cookie_page1.php
+++ b/web-fixtures/cookie_page1.php
@@ -7,7 +7,7 @@ if (!isset($cookieValue)) {
     $cookieValue = 'srv_var_is_set';
 }
 
-setcookie('srvr_cookie', $cookieValue, null, $cookieAtRootPath ? '/' : null);
+setcookie('srvr_cookie', $cookieValue, 0, $cookieAtRootPath ? '/' : '');
 ?>
 <!DOCTYPE html>
 <html>

--- a/web-fixtures/cookie_page3.php
+++ b/web-fixtures/cookie_page3.php
@@ -1,7 +1,7 @@
 <?php
 
 $hasCookie = isset($_COOKIE['foo']);
-setcookie('foo', 'bar', 0, '/', null, false, true);
+setcookie('foo', 'bar', 0, '/', '', false, true);
 
 ?>
 <!DOCTYPE html>

--- a/web-fixtures/issue140.php
+++ b/web-fixtures/issue140.php
@@ -2,7 +2,7 @@
 require_once 'utils.php';
 
 if (!empty($_POST)) {
-    setcookie("tc", $_POST['cookie_value'], null, '/');
+    setcookie("tc", $_POST['cookie_value'], 0, '/');
 } elseif (isset($_GET["show_value"])) {
     echo html_escape_value($_COOKIE["tc"]);
     die();


### PR DESCRIPTION
According to https://www.php.net/manual/en/function.setcookie.php third param of setcookie has to be of type ```int``` and fourth param has to be of type ```string```. This leads at least in ```robertfausk/mink-panther-driver``` with ```PHP 8.1``` to failing tests.

![image](https://user-images.githubusercontent.com/1651297/145445382-9d102868-c532-4a31-aeef-68bac4abbf7a.png)
