### PR TITLE
Add support for Symfony 5 in the fixtures kernel

### DIFF
--- a/src/FixturesKernel.php
+++ b/src/FixturesKernel.php
@@ -12,6 +12,9 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class FixturesKernel implements HttpKernelInterface
 {
+    /**
+     * @return Response
+     */
     public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
     {
         $this->prepareSession($request);


### PR DESCRIPTION
This is opting out of the return type deprecation instead of adding the native return type (which will be necessary for the Symfony 6 support). This is done because adding the return type requires using PHP 7.2+, and I'm not yet done with bumping the min version.