### PR TITLE
Add support for Symfony 6 and drop Symfony <4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,18 @@
 
     "require": {
         "php": ">=7.2",
+        "ext-json": "*",
         "behat/mink": "^1.9",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0.5",
+        "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0",
         "phpunit/phpunit": "^8.5.22 || ^9.5.11",
         "yoast/phpunit-polyfills": "^1.0"
     },
     "require-dev": {
-        "symfony/http-kernel": "^2.7 || ^3.2 || ^4.0 || ^5.0"
+        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0"
+    },
+    "conflict": {
+        "symfony/http-foundation": "<4.4 || >=7",
+        "symfony/http-kernel": "<4.4 || >=7"
     },
 
     "bin": [

--- a/http-kernel-fixtures/cookie_page1.php
+++ b/http-kernel-fixtures/cookie_page1.php
@@ -1,10 +1,6 @@
 <?php
     $resp = new Symfony\Component\HttpFoundation\Response();
-    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-        $cook = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set', 0, '/');
-    } else {
-        $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set', 0, '/');
-    }
+    $cook = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set', 0, '/');
     $resp->headers->setCookie($cook);
 ?>
 <!doctype html public "-//w3c//dtd xhtml 1.1//en" "http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd">

--- a/http-kernel-fixtures/cookie_page3.php
+++ b/http-kernel-fixtures/cookie_page3.php
@@ -2,11 +2,7 @@
 
 $hasCookie = $request->cookies->has('foo');
 $resp = new Symfony\Component\HttpFoundation\Response();
-if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-    $cook = Symfony\Component\HttpFoundation\Cookie::create('foo', 'bar');
-} else {
-    $cook = new Symfony\Component\HttpFoundation\Cookie('foo', 'bar');
-}
+$cook = Symfony\Component\HttpFoundation\Cookie::create('foo', 'bar');
 $resp->headers->setCookie($cook);
 
 ?>

--- a/http-kernel-fixtures/issue140.php
+++ b/http-kernel-fixtures/issue140.php
@@ -7,11 +7,7 @@
 <?php
 if ($request->isMethod('POST')) {
     $resp = new Symfony\Component\HttpFoundation\Response();
-    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-        $cook = Symfony\Component\HttpFoundation\Cookie::create('tc', $request->request->get('cookie_value'));
-    } else {
-        $cook = new Symfony\Component\HttpFoundation\Cookie('tc', $request->request->get('cookie_value'));
-    }
+    $cook = Symfony\Component\HttpFoundation\Cookie::create('tc', $request->request->get('cookie_value'));
     $resp->headers->setCookie($cook);
 } elseif ($request->query->has('show_value')) {
     echo html_escape_value($request->cookies->get('tc'));

--- a/http-kernel-fixtures/sub-folder/cookie_page1.php
+++ b/http-kernel-fixtures/sub-folder/cookie_page1.php
@@ -1,11 +1,7 @@
 <?php
     $requestUri = $request->server->get('REQUEST_URI');
     $resp = new Symfony\Component\HttpFoundation\Response();
-    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-        $cook = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
-    } else {
-        $cook = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
-    }
+    $cook = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set_sub_folder', 0, dirname($requestUri));
     $resp->headers->setCookie($cook);
 ?>
 <!doctype html public "-//w3c//dtd xhtml 1.1//en" "http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd">

--- a/http-kernel-fixtures/sub-folder/cookie_page4.php
+++ b/http-kernel-fixtures/sub-folder/cookie_page4.php
@@ -1,11 +1,7 @@
 <?php
     $resp = new Symfony\Component\HttpFoundation\Response();
     $cookiePath = dirname($request->server->get('REQUEST_URI')) . '/';
-    if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-        $cookie = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set', 0, $cookiePath);
-    } else {
-        $cookie = new Symfony\Component\HttpFoundation\Cookie('srvr_cookie', 'srv_var_is_set', 0, $cookiePath);
-    }
+    $cookie = Symfony\Component\HttpFoundation\Cookie::create('srvr_cookie', 'srv_var_is_set', 0, $cookiePath);
     $resp->headers->setCookie($cookie);
 ?>
 <!DOCTYPE html>

--- a/src/FixturesKernel.php
+++ b/src/FixturesKernel.php
@@ -2,7 +2,6 @@
 
 namespace Behat\Mink\Tests\Driver\Util;
 
-
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,10 +11,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class FixturesKernel implements HttpKernelInterface
 {
-    /**
-     * @return Response
-     */
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
         $this->prepareSession($request);
 
@@ -27,7 +23,7 @@ class FixturesKernel implements HttpKernelInterface
         return $response;
     }
 
-    private function handleFixtureRequest(Request $request)
+    private function handleFixtureRequest(Request $request): Response
     {
         $fixturesDir = realpath(__DIR__.'/../web-fixtures');
         $overwriteDir = realpath(__DIR__.'/../http-kernel-fixtures');
@@ -71,17 +67,17 @@ class FixturesKernel implements HttpKernelInterface
 
     private function saveSession(Request $request, Response $response)
     {
+        if (!$request->hasSession()) {
+            return;
+        }
+
         $session = $request->getSession();
-        if ($session && $session->isStarted()) {
+        if ($session->isStarted()) {
             $session->save();
 
             $params = session_get_cookie_params();
 
-            if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-                $cookie = Cookie::create($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
-            } else {
-                $cookie = new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
-            }
+            $cookie = Cookie::create($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
 
             $response->headers->setCookie($cookie);
         }


### PR DESCRIPTION
This also declares the proper dependencies (including a conflict rule to enforce the supported version of the Symfony components used by the kernel-based fixtures when used by drivers)