### PR TITLE
`setcookie()` expires_or_options param is integer not mixed

### DIFF
--- a/web-fixtures/sub-folder/cookie_page4.php
+++ b/web-fixtures/sub-folder/cookie_page4.php
@@ -4,7 +4,7 @@ if (!isset($cookieValue)) {
 }
 
 $cookiePath = dirname($_SERVER['REQUEST_URI']) . '/';
-setcookie('srvr_cookie', $cookieValue, null, $cookiePath);
+setcookie('srvr_cookie', $cookieValue, 0, $cookiePath);
 ?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
See https://www.php.net/manual/en/function.setcookie.php - passing a boolean here as the third of >3 parameters triggers warning in output on PHP8.1 (which prevents cookie getting set and breaks cookie tests for me).

It's also valid post 7.3 to pass an array as the third parameter. From 8.1 passing other types (eg `null` in this instance) emits a deprecation notice, and this usage will fail from 9.0.

## Steps to reproduce

To reproduce using minkphp/MinkGoutteDriver and PHP8.1

- `git clone git@github.com:minkphp/MinkGoutteDriver`
- `cd MinkGoutteDriver`
- `docker run --rm -ti -v $(pwd):/code composer bash` (currently this is PHP8.1)
- start `./vendor/bin/mink-test-server` (I used a separate `docker exec... bash` on the same container to do this)
- `./vendor/bin/phpunit` (output below)
- `curl -s http://localhost:8002/sub-folder/cookie_page4.php | grep -E '(Deprecated|Warning)'` to see why the test failed

```
bash-5.1# php -v
PHP 8.1.2 (cli) (built: Jan 21 2022 21:38:22) (NTS)
Copyright (c) The PHP Group

bash-5.1# ./vendor/bin/phpunit 
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.............................FF................................  63 / 118 ( 53%)
......S...S......S.....................................         118 / 118 (100%)

Time: 00:00.724, Memory: 14.00 MB

There were 2 failures:

1) Behat\Mink\Tests\Driver\Basic\CookieTest::testCookieInSubPath with data set #0 ('session_reset')
Failed asserting that 'Basic Form Previous cookie: NO' contains "Previous cookie: srv_var_is_set".

/code/vendor/mink/driver-testsuite/tests/Basic/CookieTest.php:113

2) Behat\Mink\Tests\Driver\Basic\CookieTest::testCookieInSubPath with data set #1 ('cookie_delete')
Failed asserting that 'Basic Form Previous cookie: NO' contains "Previous cookie: srv_var_is_set".

/code/vendor/mink/driver-testsuite/tests/Basic/CookieTest.php:113

FAILURES!
Tests: 118, Assertions: 331, Failures: 2, Skipped: 3.

bash-5.1# curl -s http://localhost:8002/sub-folder/cookie_page4.php | grep -E '(Deprecated|Warning)'
<b>Deprecated</b>:  setcookie(): Passing null to parameter #3 ($expires_or_options) of type array|int is deprecated in <b>/code/vendor/mink/driver-testsuite/web-fixtures/sub-folder/cookie_page4.php</b> on line <b>7</b><br />
<b>Warning</b>:  Cannot modify header information - headers already sent by (output started at /code/vendor/mink/driver-testsuite/web-fixtures/sub-folder/cookie_page4.php:7) in <b>/code/vendor/mink/driver-testsuite/web-fixtures/sub-folder/cookie_page4.php</b> on line <b>7</b><br />
```