### PR TITLE
Fix obsolete event.which for key testing

### DIFF
--- a/web-fixtures/js_test.html
+++ b/web-fixtures/js_test.html
@@ -77,11 +77,11 @@
             });
 
             $('.elements input.input.second').keypress(function(ev) {
-                $('.text-event').text('key pressed:' + ev.which + ' / ' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
+                $('.text-event').text('key pressed:' + (ev.keyCode || ev.charCode) + ' / ' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
             });
 
             $('.elements input.input.third').keyup(function(ev) {
-                $('.text-event').text('key upped:' + ev.which + ' / ' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
+                $('.text-event').text('key upped:' + (ev.keyCode || ev.charCode) + ' / ' + ev.altKey * 1 + ' / ' + ev.ctrlKey * 1 + ' / ' + ev.shiftKey * 1 + ' / ' + ev.metaKey * 1);
             });
 
             $( "#draggable" ).draggable();


### PR DESCRIPTION
`event.which` is obsolete and not even set in some browsers nor set by the latest syn.js

needed for https://github.com/minkphp/MinkSelenium2Driver/pull/358 PR otherwise workaround https://github.com/minkphp/MinkSelenium2Driver/commit/cfb81e9e821b5a287069f3e3b83b5d744030f3c3 is needed and the native syn.js/better mapping cannot be used


here is an example from Firefox console on real keyboard presses:
![image](https://user-images.githubusercontent.com/2228672/196061130-d25d2400-e4d4-4461-b9db-b4b16fe22111.png)
notice the keyCode and charCode is set depending on the keyPress vs keyUp/keyDown event types

same test update is proposed also in https://github.com/minkphp/driver-testsuite/pull/42, but this PR does not propose other test changes for easier review