### PR TITLE
Migrate to static data-providers

### DIFF
--- a/tests/Basic/BasicAuthTest.php
+++ b/tests/Basic/BasicAuthTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class BasicAuthTest extends TestCase
+final class BasicAuthTest extends TestCase
 {
     /**
      * @dataProvider setBasicAuthDataProvider

--- a/tests/Basic/BasicAuthTest.php
+++ b/tests/Basic/BasicAuthTest.php
@@ -20,7 +20,7 @@ final class BasicAuthTest extends TestCase
         $this->assertStringContainsString($pageText, $session->getPage()->getContent());
     }
 
-    public function setBasicAuthDataProvider()
+    public static function setBasicAuthDataProvider()
     {
         return array(
             array('mink-user', 'mink-password', 'is authenticated'),

--- a/tests/Basic/BestPracticesTest.php
+++ b/tests/Basic/BestPracticesTest.php
@@ -40,7 +40,7 @@ final class BestPracticesTest extends TestCase
         $this->assertImplementMethod($method, $driver, 'The driver is unusable when this method is not implemented.');
     }
 
-    public function provideRequiredMethods()
+    public static function provideRequiredMethods()
     {
         return array(
             array('start'),

--- a/tests/Basic/BestPracticesTest.php
+++ b/tests/Basic/BestPracticesTest.php
@@ -7,7 +7,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 /**
  * This testcase ensures that the driver implementation follows recommended practices for drivers.
  */
-class BestPracticesTest extends TestCase
+final class BestPracticesTest extends TestCase
 {
     public function testExtendsCoreDriver()
     {

--- a/tests/Basic/ContentTest.php
+++ b/tests/Basic/ContentTest.php
@@ -46,7 +46,7 @@ final class ContentTest extends TestCase
         $this->assertSame($attributeValue, $element->getAttribute($attributeName));
     }
 
-    public function getAttributeDataProvider()
+    public static function getAttributeDataProvider()
     {
         return array(
             array('with-value', 'some-value'),

--- a/tests/Basic/ContentTest.php
+++ b/tests/Basic/ContentTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class ContentTest extends TestCase
+final class ContentTest extends TestCase
 {
     public function testOuterHtml()
     {

--- a/tests/Basic/CookieTest.php
+++ b/tests/Basic/CookieTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class CookieTest extends TestCase
+final class CookieTest extends TestCase
 {
     /**
      * test cookie decoding.

--- a/tests/Basic/CookieTest.php
+++ b/tests/Basic/CookieTest.php
@@ -87,7 +87,7 @@ final class CookieTest extends TestCase
         $this->assertStringContainsString('Previous cookie: NO', $session->getPage()->getText());
     }
 
-    public function cookieWithPathsDataProvider()
+    public static function cookieWithPathsDataProvider()
     {
         return array(
             array('session_reset'),
@@ -121,14 +121,6 @@ final class CookieTest extends TestCase
         // Cookie is removed>
         $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
         $this->assertStringContainsString('Previous cookie: NO', $session->getPage()->getText());
-    }
-
-    public function cookieInSubPathProvider()
-    {
-        return array(
-            array('session_reset'),
-            array('cookie_delete'),
-        );
     }
 
     public function testReset()

--- a/tests/Basic/ErrorHandlingTest.php
+++ b/tests/Basic/ErrorHandlingTest.php
@@ -7,7 +7,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 /**
  * @group slow
  */
-class ErrorHandlingTest extends TestCase
+final class ErrorHandlingTest extends TestCase
 {
     const NOT_FOUND_XPATH = '//html/./invalid';
 

--- a/tests/Basic/HeaderTest.php
+++ b/tests/Basic/HeaderTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class HeaderTest extends TestCase
+final class HeaderTest extends TestCase
 {
     /**
      * test referrer.

--- a/tests/Basic/IFrameTest.php
+++ b/tests/Basic/IFrameTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class IFrameTest extends TestCase
+final class IFrameTest extends TestCase
 {
     public function testIFrame()
     {

--- a/tests/Basic/NavigationTest.php
+++ b/tests/Basic/NavigationTest.php
@@ -5,7 +5,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 use Behat\Mink\Tests\Driver\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
-class NavigationTest extends TestCase
+final class NavigationTest extends TestCase
 {
     use AssertionRenames;
 

--- a/tests/Basic/ScreenshotTest.php
+++ b/tests/Basic/ScreenshotTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class ScreenshotTest extends TestCase
+final class ScreenshotTest extends TestCase
 {
     public function testScreenshot()
     {

--- a/tests/Basic/StatusCodeTest.php
+++ b/tests/Basic/StatusCodeTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class StatusCodeTest extends TestCase
+final class StatusCodeTest extends TestCase
 {
     public function testStatuses()
     {

--- a/tests/Basic/TraversingTest.php
+++ b/tests/Basic/TraversingTest.php
@@ -5,7 +5,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 use Behat\Mink\Tests\Driver\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
-class TraversingTest extends TestCase
+final class TraversingTest extends TestCase
 {
     use AssertionRenames;
 

--- a/tests/Basic/VisibilityTest.php
+++ b/tests/Basic/VisibilityTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class VisibilityTest extends TestCase
+final class VisibilityTest extends TestCase
 {
     public function testVisibility()
     {

--- a/tests/Css/HoverTest.php
+++ b/tests/Css/HoverTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Css;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class HoverTest extends TestCase
+final class HoverTest extends TestCase
 {
     /**
      * @group mouse-events

--- a/tests/Form/CheckboxTest.php
+++ b/tests/Form/CheckboxTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class CheckboxTest extends TestCase
+final class CheckboxTest extends TestCase
 {
     public function testManipulate()
     {

--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class GeneralTest extends TestCase
+final class GeneralTest extends TestCase
 {
     // test multiple submit buttons
     public function testIssue212()

--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -76,7 +76,7 @@ final class GeneralTest extends TestCase
         }
     }
 
-    public function formSubmitWaysDataProvider()
+    public static function formSubmitWaysDataProvider()
     {
         return array(
             array('Save'),

--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class Html5Test extends TestCase
+final class Html5Test extends TestCase
 {
     public function testHtml5FormInputAttribute()
     {

--- a/tests/Form/RadioTest.php
+++ b/tests/Form/RadioTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class RadioTest extends TestCase
+final class RadioTest extends TestCase
 {
     /**
      * @before

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -77,7 +77,7 @@ OUT;
         $this->assertTrue($option->isSelected());
     }
 
-    public function elementSelectedStateCheckDataProvider()
+    public static function elementSelectedStateCheckDataProvider()
     {
         return array(
             array('select_number', '30', 'thirty'),

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class SelectTest extends TestCase
+final class SelectTest extends TestCase
 {
     public function testMultiselect()
     {

--- a/tests/Js/ChangeEventTest.php
+++ b/tests/Js/ChangeEventTest.php
@@ -58,7 +58,7 @@ final class ChangeEventTest extends TestCase
         }
     }
 
-    public function setValueChangeEventDataProvider()
+    public static function setValueChangeEventDataProvider()
     {
         $file1 = __DIR__ . '/../../web-fixtures/file1.txt';
         $file2 = __DIR__ . '/../../web-fixtures/file2.txt';
@@ -90,7 +90,7 @@ final class ChangeEventTest extends TestCase
         $this->assertElementChangeCount($elementId);
     }
 
-    public function selectOptionChangeEventDataProvider()
+    public static function selectOptionChangeEventDataProvider()
     {
         return array(
             'select' => array('the-select', '30'),
@@ -140,7 +140,7 @@ final class ChangeEventTest extends TestCase
         $this->assertElementChangeCount('the-checked-checkbox');
     }
 
-    public function checkboxTestWayDataProvider()
+    public static function checkboxTestWayDataProvider()
     {
         return array(
             array(true),

--- a/tests/Js/ChangeEventTest.php
+++ b/tests/Js/ChangeEventTest.php
@@ -7,7 +7,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 /**
  * @group slow
  */
-class ChangeEventTest extends TestCase
+final class ChangeEventTest extends TestCase
 {
     /**
      * 'change' event should be fired after selecting an <option> in a <select>.

--- a/tests/Js/EventsTest.php
+++ b/tests/Js/EventsTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Js;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class EventsTest extends TestCase
+final class EventsTest extends TestCase
 {
     /**
      * @group mouse-events

--- a/tests/Js/EventsTest.php
+++ b/tests/Js/EventsTest.php
@@ -114,7 +114,7 @@ final class EventsTest extends TestCase
         $this->assertEquals('key upped:78 / '.$eventProperties, $event->getText());
     }
 
-    public function provideKeyboardEventsModifiers()
+    public static function provideKeyboardEventsModifiers()
     {
         return array(
             'none' => array(null, '0 / 0 / 0 / 0'),

--- a/tests/Js/JavascriptEvaluationTest.php
+++ b/tests/Js/JavascriptEvaluationTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Js;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class JavascriptEvaluationTest extends TestCase
+final class JavascriptEvaluationTest extends TestCase
 {
     /**
      * Tests, that `wait` method returns check result after exit.

--- a/tests/Js/JavascriptEvaluationTest.php
+++ b/tests/Js/JavascriptEvaluationTest.php
@@ -55,7 +55,7 @@ final class JavascriptEvaluationTest extends TestCase
         $this->assertEquals('Hello world', $heading->getText());
     }
 
-    public function provideExecutedScript()
+    public static function provideExecutedScript()
     {
         return array(
             array('document.querySelector("h1").textContent = "Hello world"'),
@@ -77,7 +77,7 @@ final class JavascriptEvaluationTest extends TestCase
         $this->assertSame(2, $this->getSession()->evaluateScript($script));
     }
 
-    public function provideEvaluatedScript()
+    public static function provideEvaluatedScript()
     {
         return array(
             array('1 + 1'),

--- a/tests/Js/JavascriptTest.php
+++ b/tests/Js/JavascriptTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Js;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class JavascriptTest extends TestCase
+final class JavascriptTest extends TestCase
 {
     public function testAriaRoles()
     {

--- a/tests/Js/WindowTest.php
+++ b/tests/Js/WindowTest.php
@@ -4,7 +4,7 @@ namespace Behat\Mink\Tests\Driver\Js;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class WindowTest extends TestCase
+final class WindowTest extends TestCase
 {
     public function testWindow()
     {


### PR DESCRIPTION
This PR migrates all data providers to be static methods as non-static ones are deprecated in PHPUnit 9.6 and unsupported in PHPUnit 10.