### PR TITLE
Fix tests failing from format ambiguities

### DIFF
--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -104,25 +104,25 @@ OUT;
         $this->getSession()->visit($this->pathTo('html5_types.html'));
         $page = $this->getSession()->getPage();
 
-        $page->fillField('url', 'http://mink.behat.org/');
+        $page->fillField('url', 'https://mink.behat.org/');
         $page->fillField('email', 'mink@example.org');
         $page->fillField('number', '6');
         $page->fillField('search', 'mink');
-        $page->fillField('date', '2014-05-19');
-        $page->fillField('time', '12:12');
+        $page->fillField('date', '1111-11-11');
+        $page->fillField('time', '14:12');
         $page->fillField('color', '#ff00aa');
 
         $page->pressButton('Submit');
 
         $out = <<<'OUT'
   color = `#ff00aa`,
-  date = `2014-05-19`,
+  date = `1111-11-11`,
   email = `mink@example.org`,
   number = `6`,
   search = `mink`,
   submit_button = `Submit`,
-  time = `12:12`,
-  url = `http://mink.behat.org/`,
+  time = `14:12`,
+  url = `https://mink.behat.org/`,
 OUT;
 
         $this->assertStringContainsString($out, $page->getContent());


### PR DESCRIPTION
There are 3 fixes:
1. use https url - just a nice to have to avoid IDE complaints on using unsafe protocol
2. use `14:12` instead of `12:12`; without this change the browser doesn't know if it's AM or PM, causing the form to be invalid and not submittable. Using `14`, causes the browser to correctly guess we're interested in PM.
3. filling the date was the trickiest problem, [since as of now](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#handling_browser_support
), there's no sane way to force a specific date field format. The fix is (ironically) to use the ambiguity behind `1111-11-11` which gives us a valid date no matter what. 🤷 
