### PR TITLE
Deprecate marking tests as skipped for unsupported actions

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,6 +74,7 @@ abstract class TestCase extends BaseTestCase
     protected function onNotSuccessfulTest(\Throwable $e): void
     {
         if ($e instanceof UnsupportedDriverActionException) {
+            @trigger_error(sprintf('Relying on catching "UnsupportedDriverActionException" to mark tests as skipped is deprecated. The test "%s::%s" should be marked as skipped through the test config.', get_class($this), $this->getName(false)), E_USER_DEPRECATED);
             $this->markTestSkipped($e->getMessage());
         }
 


### PR DESCRIPTION
This relies on a feature/hack that is not supported anymore in PHPUnit 10. Drivers should instead skip those tests through the `skipMessage` method of their test config.

Refs #65. Before merging this one, we need to update all drivers. This deprecation makes it easier to see what needs to be updated.