### PR TITLE
Remove wrong request transformation

### DIFF
--- a/http-kernel-fixtures/advanced_form_post.php
+++ b/http-kernel-fixtures/advanced_form_post.php
@@ -12,10 +12,6 @@ error_reporting(0);
 $POST = $request->request->all();
 $FILES = $request->files->all();
 
-if (isset($POST['select_multiple_numbers']) && false !== strpos($POST['select_multiple_numbers'][0], ',')) {
-    $POST['select_multiple_numbers'] = explode(',', $POST['select_multiple_numbers'][0]);
-}
-
 // checkbox can have any value and will be successful in case "on"
 // http://www.w3.org/TR/html401/interact/forms.html#checkbox
 $POST['agreement'] = isset($POST['agreement']) ? 'on' : 'off';

--- a/web-fixtures/advanced_form_post.php
+++ b/web-fixtures/advanced_form_post.php
@@ -11,10 +11,6 @@ error_reporting(0);
 
 require_once 'utils.php';
 
-if (isset($_POST['select_multiple_numbers']) && false !== strpos($_POST['select_multiple_numbers'][0], ',')) {
-    $_POST['select_multiple_numbers'] = explode(',', $_POST['select_multiple_numbers'][0]);
-}
-
 $_POST['agreement'] = isset($_POST['agreement']) ? 'on' : 'off';
 ksort($_POST);
 echo html_escape_value(mink_dump($_POST)) . "\n";


### PR DESCRIPTION
This transformation of the input is not needed for drivers submitting values properly and could hide invalid implementations.