### PR TITLE
Fix TypeError

### DIFF
--- a/tests/Js/EventsTest.php
+++ b/tests/Js/EventsTest.php
@@ -88,7 +88,7 @@ final class EventsTest extends TestCase
     /**
      * @dataProvider provideKeyboardEventsModifiers
      */
-    public function testKeyboardEvents(string $modifier, string $eventProperties)
+    public function testKeyboardEvents(?string $modifier, string $eventProperties)
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
         $webAssert = $this->getAssertSession();


### PR DESCRIPTION
Hey, the first scenario provided by provideKeyboardEventsModifiers attempts to pass a null to the test method's first argument, defined as a string, causing a TypeError:
https://github.com/minkphp/driver-testsuite/blob/3bee79433f88e78ab696e33cb9a71b26037b4f73/tests/Js/EventsTest.php#L120
https://github.com/minkphp/driver-testsuite/blob/3bee79433f88e78ab696e33cb9a71b26037b4f73/tests/Js/EventsTest.php#L91
<img width="963" alt="image" src="https://github.com/minkphp/driver-testsuite/assets/230049/6c983de7-2d1d-437c-af25-cb875c9fc686">
