### PR TITLE
Fix phpstan error

### DIFF
--- a/http-kernel-fixtures/print_cookies.php
+++ b/http-kernel-fixtures/print_cookies.php
@@ -18,9 +18,6 @@
         $cookies['srvr_cookie'] = $srvrCookie;
     }
 
-    foreach ($cookies as $name => $val) {
-        $cookies[$name] = (string)$val;
-    }
     echo html_escape_value(mink_dump($cookies));
     ?>
 </pre>


### PR DESCRIPTION
Fixes this failure: https://github.com/minkphp/driver-testsuite/actions/runs/5501534048/jobs/10025187827?pr=75

The `mink_dump` function seems to handle mixed-type values just fine.
While this change is not backward compatible, (e.g. `(int)42` was rendered as `` `42` `` before and now it would be `42`), the tests still passed just fine, so I'm confident that it's not a problem.