### PR TITLE
Refactor testResizeWindow; increase window size for MSEdge

### DIFF
--- a/tests/Js/WindowTest.php
+++ b/tests/Js/WindowTest.php
@@ -71,23 +71,26 @@ final class WindowTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/index.html'));
         $session = $this->getSession();
+        $testWidth = 640;
+        $testHeight = 480;
 
-        $session->resizeWindow(400, 300);
+        $session->resizeWindow($testWidth, $testHeight);
         $session->wait(1000, 'false');
-        $jsWindowSizeScript = <<<'JS'
-        (function(){
-          var boolSizeCheck = Math.abs(window.outerHeight - 300) <= 100 && Math.abs(window.outerWidth - 400) <= 100;
-          if (boolSizeCheck){
-            return true;
-          }
-          var w = window,
-              d = document,
-              e = d.documentElement,
-              g = d.getElementsByTagName('body')[0],
-              x = w.innerWidth || e.clientWidth || g.clientWidth,
-              y = w.innerHeight|| e.clientHeight|| g.clientHeight;
-          boolSizeCheck = Math.abs(y - 300) <= 100 && Math.abs(x - 400) <= 100;
-          return boolSizeCheck;
+        $jsWindowSizeScript = <<<"JS"
+        (function () {
+            var check =
+                function(w, h){
+                    return Math.abs(w - $testWidth) <= 100
+                        && Math.abs(h - $testHeight) <= 100;
+                },
+                htmlElem = document.documentElement,
+                bodyElem = document.getElementsByTagName('body')[0];
+
+            return check(window.outerWidth, window.outerHeight)
+                || check(
+                    window.innerWidth || htmlElem.clientWidth || bodyElem.clientWidth,
+                    window.innerHeight || htmlElem.clientHeight || bodyElem.clientHeight
+                );
         })();
 JS;
 

--- a/tests/Js/WindowTest.php
+++ b/tests/Js/WindowTest.php
@@ -71,18 +71,18 @@ final class WindowTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/index.html'));
         $session = $this->getSession();
-        $testWidth = 640;
-        $testHeight = 480;
+        $expectedWidth = 640;
+        $expectedHeight = 480;
 
-        $session->resizeWindow($testWidth, $testHeight);
+        $session->resizeWindow($expectedWidth, $expectedHeight);
         $session->wait(1000, 'false');
+
         $jsWindowSizeScript = <<<"JS"
         (function () {
-            var check =
-                function(w, h){
-                    return Math.abs(w - $testWidth) <= 100
-                        && Math.abs(h - $testHeight) <= 100;
-                },
+            var check = function (actualWidth, actualHeight) {
+                    return Math.abs(actualWidth - $expectedWidth) <= 100
+                        && Math.abs(actualHeight - $expectedHeight) <= 100;
+                    },
                 htmlElem = document.documentElement,
                 bodyElem = document.getElementsByTagName('body')[0];
 
@@ -93,7 +93,6 @@ final class WindowTest extends TestCase
                 );
         })();
 JS;
-
         $this->assertTrue($session->evaluateScript($jsWindowSizeScript));
     }
 


### PR DESCRIPTION
Main motivation for this: Edge most of the time fails this test because 500x300 is (apparently) too small.

1. I did a small refactor of the JS side, so it's clearer how it behaves (and also reuses the same values).
2. I increased the window size to 640x480 - test is now passing on MSEdge reliably.