### PR TITLE
Remove tests enforcing a DriverException for null values in setValue

### DIFF
--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -368,7 +368,6 @@ OUT;
 
     public static function provideInvalidValues(): iterable
     {
-        $nullValue = ['null', null];
         $trueValue = ['true', true];
         $falseValue = ['false', false];
         $arrayValue = ['array', ['bad']];
@@ -376,10 +375,10 @@ OUT;
 
         $scenarios = [
             // field type, name or id, list of values to check
-            ['file', 'about', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['textarea', 'notes', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['text', 'first_name', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['button', 'submit', [$nullValue, $trueValue, $falseValue, $arrayValue, $stringValue]],
+            ['file', 'about', [$trueValue, $falseValue, $arrayValue]],
+            ['textarea', 'notes', [$trueValue, $falseValue, $arrayValue]],
+            ['text', 'first_name', [$trueValue, $falseValue, $arrayValue]],
+            ['button', 'submit', [$trueValue, $falseValue, $arrayValue, $stringValue]],
         ];
 
         foreach ($scenarios as [$fieldType, $fieldNameOrId, $values]) {

--- a/tests/Form/Html5Test.php
+++ b/tests/Form/Html5Test.php
@@ -179,20 +179,19 @@ OUT;
 
     public static function provideInvalidValues(): iterable
     {
-        $nullValue = ['null', null];
         $trueValue = ['true', true];
         $falseValue = ['false', false];
         $arrayValue = ['empty array', []];
 
         $scenarios = [
             // field type, name or id, list of values to check
-            ['url', 'url', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['email', 'email', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['number', 'number', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['search', 'search', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['color', 'color', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['date', 'date', [$nullValue, $trueValue, $falseValue, $arrayValue]],
-            ['time', 'time', [$nullValue, $trueValue, $falseValue, $arrayValue]],
+            ['url', 'url', [$trueValue, $falseValue, $arrayValue]],
+            ['email', 'email', [$trueValue, $falseValue, $arrayValue]],
+            ['number', 'number', [$trueValue, $falseValue, $arrayValue]],
+            ['search', 'search', [$trueValue, $falseValue, $arrayValue]],
+            ['color', 'color', [$trueValue, $falseValue, $arrayValue]],
+            ['date', 'date', [$trueValue, $falseValue, $arrayValue]],
+            ['time', 'time', [$trueValue, $falseValue, $arrayValue]],
         ];
 
         foreach ($scenarios as [$fieldType, $fieldNameOrId, $values]) {


### PR DESCRIPTION
The contract of the method says that the argument type is `string|bool|array`. Passing null does not respect the contract. So there is no reason for the driver testsuite to expect drivers to throw a DriverException for this case.

This was introduced in #78 and #79.
I caught this when updating BrowserKitDriver to make those new tests pass, when phpstan told me that the value cannot be `null` and so the `$value === null` condition was always false.