### PR TITLE
Added tests to verify, that iframe switching by an id works

### DIFF
--- a/tests/Basic/IFrameTest.php
+++ b/tests/Basic/IFrameTest.php
@@ -6,7 +6,10 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 final class IFrameTest extends TestCase
 {
-    public function testIFrame(): void
+    /**
+     * @dataProvider iFrameDataProvider
+     */
+    public function testIFrame(string $iframeIdentifier, string $elementSelector, string $elementContent): void
     {
         $this->getSession()->visit($this->pathTo('/iframe.html'));
         $webAssert = $this->getAssertSession();
@@ -14,14 +17,25 @@ final class IFrameTest extends TestCase
         $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Main window div text', $el->getText());
 
-        $this->getSession()->switchToIFrame('subframe');
+        $this->getSession()->switchToIFrame($iframeIdentifier);
 
-        $el = $webAssert->elementExists('css', '#text');
-        $this->assertSame('iFrame div text', $el->getText());
+        $el = $webAssert->elementExists('css', $elementSelector);
+        $this->assertSame($elementContent, $el->getText());
 
         $this->getSession()->switchToIFrame();
 
         $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Main window div text', $el->getText());
+    }
+
+    /**
+     * @return array
+     */
+    public static function iFrameDataProvider()
+    {
+        return array(
+            'by name' => array('subframe_by_name', '#text', 'iFrame div text'),
+            'by id' => array('subframe_by_id', '#foobar', 'Some accentués characters'),
+        );
     }
 }

--- a/web-fixtures/iframe.html
+++ b/web-fixtures/iframe.html
@@ -2,7 +2,9 @@
 <html>
 <body>
 
-<iframe src="iframe_inner.html" name="subframe"></iframe>
+<iframe src="iframe_inner.html" name="subframe_by_name"></iframe>
+
+<iframe src="issue131.html" name="subframe_by_id"></iframe>
 
 <div id="text">
     Main window div text


### PR DESCRIPTION
Existing tests only cover iframe switching by name. This PR adds these tests:

1. frame switching by an id;
2. frame switching by an index.

See https://github.com/minkphp/Mink/issues/866 (PR 2 of 4)

The PhpStan correctly reports this, but I can't fix it due to the problem described in the above-mentioned issue.
```
Error: Parameter #1 $name of method Behat\Mink\Session::switchToIFrame() expects string|null, int|string given.
```