### PR TITLE
Fixed file upload test during the build on Selenium 3

### DIFF
--- a/tests/Js/ChangeEventTest.php
+++ b/tests/Js/ChangeEventTest.php
@@ -65,8 +65,13 @@ final class ChangeEventTest extends TestCase
 
     public static function setValueChangeEventDataProvider(): iterable
     {
-        $file1 = __DIR__ . '/../../web-fixtures/file1.txt';
-        $file2 = __DIR__ . '/../../web-fixtures/file2.txt';
+        if (getenv('GITHUB_ACTION')) {
+            $file1 = '/etc/hosts.allow';
+            $file2 = '/etc/hosts.deny';
+        } else {
+            $file1 = __DIR__ . '/../../web-fixtures/file1.txt';
+            $file2 = __DIR__ . '/../../web-fixtures/file2.txt';
+        }
 
         return [
             'input default' => ['the-input-default', 'from empty', 'from existing'],


### PR DESCRIPTION
Fixes this error from the https://github.com/minkphp/MinkSelenium2Driver/pull/383:

```
2) Behat\Mink\Tests\Driver\Js\ChangeEventTest::testSetValueChangeEvent with data set "file" ('the-file', '/home/runner/work/MinkSeleniu...e1.txt', '/home/runner/work/MinkSeleniu...e2.txt')
WebDriver\Exception\InvalidArgument: File not found: /home/runner/work/MinkSelenium2Driver/MinkSelenium2Driver/vendor/mink/driver-testsuite/web-fixtures/file1.txt
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:25:53'
System info: host: 'fv-az697-197', ip: '10.1.0.44', os.name: 'Linux', os.arch: 'amd64', os.version: '5.15.0-1056-azure', java.version: '1.8.0_292'
Driver info: driver.version: unknown
```

Inspired by the @mvorisek work on the https://github.com/minkphp/driver-testsuite/pull/60.
