### PR TITLE
Focus element before testing blur

### DIFF
--- a/tests/Js/EventsTest.php
+++ b/tests/Js/EventsTest.php
@@ -69,6 +69,7 @@ final class EventsTest extends TestCase
         $focusBlurDetector = $this->getAssertSession()->elementExists('css', '.elements input#focus-blur-detector');
         $this->assertEquals('no action detected', $focusBlurDetector->getValue());
 
+        $focusBlurDetector->focus();
         $focusBlurDetector->blur();
         $this->assertEquals('blured', $focusBlurDetector->getValue());
     }


### PR DESCRIPTION
This fix addresses the point here: https://github.com/minkphp/webdriver-classic-driver/pull/6#discussion_r1516674610

Partially duplicates https://github.com/minkphp/driver-testsuite/pull/29 ([here](https://github.com/minkphp/driver-testsuite/pull/29/files#diff-cd4e4a44bb7db8b4d355edbf0deca9b154f6d6f2cce6a2bacb663f3bbb7c1019R81))