### PR TITLE
Corrected a frame test fixture

### DIFF
--- a/web-fixtures/iframe.html
+++ b/web-fixtures/iframe.html
@@ -4,7 +4,7 @@
 
 <iframe src="iframe_inner.html" name="subframe_by_name"></iframe>
 
-<iframe src="issue131.html" name="subframe_by_id"></iframe>
+<iframe src="issue131.html" id="subframe_by_id"></iframe>
 
 <div id="text">
     Main window div text


### PR DESCRIPTION
The #87 add test, that verifies frame switching by an ID. However I've just noticed that both frames have only `name` attribute.

This is fixed now.