### PR TITLE
Fixed return type of the "testDragDropOntoHiddenItself" test

### DIFF
--- a/tests/Js/JavascriptTest.php
+++ b/tests/Js/JavascriptTest.php
@@ -31,7 +31,7 @@ final class JavascriptTest extends TestCase
     }
 
     // https://github.com/minkphp/MinkSelenium2Driver/pull/359
-    public function testDragDropOntoHiddenItself()
+    public function testDragDropOntoHiddenItself():void
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
         $webAssert = $this->getAssertSession();


### PR DESCRIPTION
Corrects PhpStan report on #59, which was merged last week.

```
 ------ ---------------------------------------------------------------------------------------------------------------- 
  Line   tests/Js/JavascriptTest.php                                                                                     
 ------ ---------------------------------------------------------------------------------------------------------------- 
  34     Method Behat\Mink\Tests\Driver\Js\JavascriptTest::testDragDropOntoHiddenItself() has no return type specified.  
 ------ ---------------------------------------------------------------------------------------------------------------- 
```

P.S.
I'm not sure why, but no GitHub Actions were executed on that PR and therefore PhpStan wasn't able to report this prior to PR merging.