### PR TITLE
Test using invalid values for checkbox

### DIFF
--- a/tests/Form/GeneralTest.php
+++ b/tests/Form/GeneralTest.php
@@ -379,6 +379,7 @@ OUT;
             ['textarea', 'notes', [$trueValue, $falseValue, $arrayValue]],
             ['text', 'first_name', [$trueValue, $falseValue, $arrayValue]],
             ['button', 'submit', [$trueValue, $falseValue, $arrayValue, $stringValue]],
+            ['checkbox', 'agreement', [$arrayValue, $stringValue]],
         ];
 
         foreach ($scenarios as [$fieldType, $fieldNameOrId, $values]) {


### PR DESCRIPTION
Relates to https://github.com/minkphp/webdriver-classic-driver/issues/10.

Failure is solved by https://github.com/minkphp/driver-testsuite/pull/100.