### PR TITLE
Fix PHP 8.5 deprecation

### DIFF
--- a/tests/Basic/ScreenshotTest.php
+++ b/tests/Basic/ScreenshotTest.php
@@ -25,6 +25,8 @@ final class ScreenshotTest extends TestCase
             $this->fail('The screenshot should be a valid image');
         }
 
-        imagedestroy($img);
+        if (\PHP_VERSION_ID < 80000) {
+            imagedestroy($img);
+        }
     }
 }


### PR DESCRIPTION
`imagedestroy` is a no-op on PHP 8.0+ due to the migration to objects and is deprecated as of PHP 8.5.